### PR TITLE
Adds .gitignore rules for files generated by autoreconf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ GTAGS
 aclocal.m4
 configure
 m4/*.m4
+src/baton-chmod
+src/baton-get
+src/baton-list
+src/baton-metamod
+src/baton-metaquery
+src/baton-metasuper


### PR DESCRIPTION
When running `autoreconf -fvi`, several files were generated
that were not ignored by the existing .gitignore rules:

```
aclocal.m4 configure m4/libtool.m4 m4/ltoptions.m4 m4/ltsugar.m4
m4/ltversion.m4 m4/lt~obsolete.m4
```

Also, after a successful build, `git status` reports on the built binaries:

```
        src/baton-chmod
        src/baton-get
        src/baton-list
        src/baton-metamod
        src/baton-metaquery
        src/baton-metasuper
```

All should now be ignored by the updated .gitignore 
