### PR TITLE
iRODS 4.1.0 compatability

### DIFF
--- a/.travis.setup_irods
+++ b/.travis.setup_irods
@@ -9,6 +9,7 @@ TEMPORARY_zone_key
 TEMPORARY_32byte_negotiation_key
 1248
 TEMPORARY__32byte_ctrl_plane_key
+off
 irods
 irods
 yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - PGVERSION="9.3"
     - CK_DEFAULT_TIMEOUT=20
     - WTSI_NPG_URL=https://github.com/wtsi-npg/irods
-    - WTSI_NPG_SHA1=4de42a6
+    - WTSI_NPG_SHA1=6765986
     - PG_PLUGIN_VERSION=1.5
   matrix:
     - IRODS_VERSION=3.3.1

--- a/configure.ac
+++ b/configure.ac
@@ -311,14 +311,14 @@ AS_IF(
     [AC_MSG_ERROR([failed to detect the packaged iRODS 4.x installation])],
   [test "x$IS_PACKAGED_INSTALL" = "xyes" && test "x$HAVE_IRODS4" = "xyes"],
     [AC_MSG_NOTICE([detected the packaged iRODS 4.x installation])
-     AC_DEFINE([HAVE_IRODS4], [], [iRODS 4.x])
+     AC_DEFINE([HAVE_IRODS4], [1], [iRODS 4.x])
      CPPFLAGS="${IRODS4_CPPFLAGS}"
      LDFLAGS="${IRODS4_LDFLAGS}"
      LDLIBS="${IRODS4_LIBS}"
      LIBS="${IRODS4_LIBS}"],
   [test "x$IS_PACKAGED_INSTALL" = "xno" && test "x$HAVE_IRODS3" = "xyes"],
     [AC_MSG_NOTICE([detected an iRODS 3.3.x installation in ${IRODS_HOME}])
-     AC_DEFINE([HAVE_IRODS3], [], [iRODS 3.3.x])
+     AC_DEFINE([HAVE_IRODS3], [1], [iRODS 3.3.x])
      CPPFLAGS="${IRODS3_CPPFLAGS}"
      LDFLAGS="${IRODS3_LDFLAGS}"
      LDLIBS="${IRODS3_LIBS}"
@@ -326,7 +326,7 @@ AS_IF(
   [test "x$IS_PACKAGED_INSTALL" = "xno" && test "x$HAVE_IRODS3" = "xno" &&
    test "x$HAVE_IRODS4" = "xyes"],
     [AC_MSG_NOTICE([detected an iRODS 4.x installation in ${IRODS_HOME}])
-     AC_DEFINE([HAVE_IRODS4], [], [iRODS 4.x])
+     AC_DEFINE([HAVE_IRODS4], [1], [iRODS 4.x])
      CPPFLAGS="${IRODS4_CPPFLAGS}"
      LDFLAGS="${IRODS4_LDFLAGS}"
      LDLIBS="${IRODS4_LIBS}"

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -30,9 +30,10 @@ install_3_3_1() {
 }
 
 install_4_1_0() {
-    sudo apt-get install -qq python-psutil
+    sudo apt-get install -qq python-psutil python-requests
     sudo apt-get install -qq python-sphinx
     sudo apt-get install super libjson-perl jq
+    sudo -H pip install jsonschema
 
     sudo dpkg -i irods-icat-${IRODS_VERSION}-64bit.deb irods-database-plugin-postgres-${PG_PLUGIN_VERSION}.deb
     sudo dpkg -i irods-runtime-${IRODS_VERSION}-64bit.deb irods-dev-${IRODS_VERSION}-64bit.deb

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,7 +16,7 @@ LT_VERSION_INFO=$(LT_LIB_CURRENT):$(LT_LIB_REVISION):$(LT_LIB_AGE)
 lib_LTLIBRARIES = libbaton.la
 
 libbaton_includedir = $(includedir)/baton
-libbaton_include_HEADERS = baton.h error.h log.h json.h json_query.h query.h read.h compat_checksum.h utilities.h
+libbaton_include_HEADERS = baton.h error.h irods_api.h irods_3_x_x.h irods_4_1_x.h log.h json.h json_query.h query.h read.h compat_checksum.h utilities.h
 libbaton_la_SOURCES = baton.c error.c log.c json.c json_query.c query.c read.c compat_checksum.c utilities.c
 libbaton_la_LDFLAGS = -version-info $(LT_VERSION_INFO)
 

--- a/src/baton-chmod.c
+++ b/src/baton-chmod.c
@@ -24,17 +24,6 @@
 #include <jansson.h>
 
 #include "config.h"
-
-#ifdef HAVE_IRODS3
-#include "rodsClient.h"
-#include "rodsPath.h"
-#endif
-
-#ifdef HAVE_IRODS4
-#include "rodsClient.hpp"
-#include "rodsPath.hpp"
-#endif
-
 #include "baton.h"
 #include "json.h"
 #include "log.h"

--- a/src/baton-get.c
+++ b/src/baton-get.c
@@ -24,17 +24,6 @@
 #include <jansson.h>
 
 #include "config.h"
-
-#ifdef HAVE_IRODS3
-#include "rodsClient.h"
-#include "rodsPath.h"
-#endif
-
-#ifdef HAVE_IRODS4
-#include "rodsClient.hpp"
-#include "rodsPath.hpp"
-#endif
-
 #include "baton.h"
 #include "json.h"
 #include "log.h"

--- a/src/baton-list.c
+++ b/src/baton-list.c
@@ -25,17 +25,6 @@
 #include <jansson.h>
 
 #include "config.h"
-
-#ifdef HAVE_IRODS3
-#include "rodsClient.h"
-#include "rodsPath.h"
-#endif
-
-#ifdef HAVE_IRODS4
-#include "rodsClient.hpp"
-#include "rodsPath.hpp"
-#endif
-
 #include "baton.h"
 #include "json.h"
 #include "log.h"

--- a/src/baton-metamod.c
+++ b/src/baton-metamod.c
@@ -25,17 +25,6 @@
 #include <jansson.h>
 
 #include "config.h"
-
-#ifdef HAVE_IRODS3
-#include "rodsClient.h"
-#include "rodsPath.h"
-#endif
-
-#ifdef HAVE_IRODS4
-#include "rodsClient.hpp"
-#include "rodsPath.hpp"
-#endif
-
 #include "baton.h"
 #include "json.h"
 #include "log.h"

--- a/src/baton-metaquery.c
+++ b/src/baton-metaquery.c
@@ -26,17 +26,6 @@
 #include <jansson.h>
 
 #include "config.h"
-
-#ifdef HAVE_IRODS3
-#include "rodsClient.h"
-#include "rodsPath.h"
-#endif
-
-#ifdef HAVE_IRODS4
-#include "rodsClient.hpp"
-#include "rodsPath.hpp"
-#endif
-
 #include "baton.h"
 #include "json.h"
 #include "log.h"

--- a/src/baton-metasuper.c
+++ b/src/baton-metasuper.c
@@ -25,17 +25,6 @@
 #include <jansson.h>
 
 #include "config.h"
-
-#ifdef HAVE_IRODS3
-#include "rodsClient.h"
-#include "rodsPath.h"
-#endif
-
-#ifdef HAVE_IRODS4
-#include "rodsClient.hpp"
-#include "rodsPath.hpp"
-#endif
-
 #include "baton.h"
 #include "json.h"
 #include "log.h"

--- a/src/baton.c
+++ b/src/baton.c
@@ -29,21 +29,6 @@
 #include <jansson.h>
 
 #include "config.h"
-
-#ifdef HAVE_IRODS3
-#include "rodsType.h"
-#include "rodsErrorTable.h"
-#include "rodsClient.h"
-#include "miscUtil.h"
-#endif
-
-#ifdef HAVE_IRODS4
-#include "rodsType.hpp"
-#include "rodsErrorTable.hpp"
-#include "rodsClient.hpp"
-#include "miscUtil.hpp"
-#endif
-
 #include "baton.h"
 #include "error.h"
 #include "json.h"

--- a/src/baton.h
+++ b/src/baton.h
@@ -25,20 +25,8 @@
 #include <jansson.h>
 
 #include "config.h"
-
-#ifdef HAVE_IRODS3
-#include "rcConnect.h"
-#include "rodsClient.h"
-#include "rodsPath.h"
-#endif
-
-#ifdef HAVE_IRODS4
-#include "rcConnect.hpp"
-#include "rodsClient.hpp"
-#include "rodsPath.hpp"
-#endif
-
 #include "error.h"
+#include "irods_api.h"
 #include "query.h"
 #include "utilities.h"
 

--- a/src/compat_checksum.h
+++ b/src/compat_checksum.h
@@ -19,23 +19,14 @@
  */
 
 #include "config.h"
+#include "irods_api.h"
 
-/*
-  iRODS 3.x shares the same checksum API as iRODS 4.0.x, while 4.1.x
-  uses openssl directly. Backwards compatibility was broken for the
-  iRODS checksum API in 4.1.0. Since baton needs to continue support
-  for both 3.3.1 and 4.1.x this compatability shim was introduced and
-  baton's support for iRODS 4.0.x discontinued. It's a long-winded way
-  of doing things, but it's very clear what's going on.
- */
-
-#ifdef HAVE_IRODS3
-#include "md5Checksum.h"
-#endif
-
-#ifdef HAVE_IRODS4
-#include "openssl/md5.h"
-#endif
+// iRODS 3.x shares the same checksum API as iRODS 4.0.x, while 4.1.x
+// uses openssl directly. Backwards compatibility was broken for the
+// iRODS checksum API in 4.1.0. Since baton needs to continue support
+// for both 3.3.1 and 4.1.x this compatability shim was introduced and
+// baton's support for iRODS 4.0.x discontinued. It's a long-winded way
+// of doing things, but it's very clear what's going on.
 
 // MD5_CTX is the symbol that clashes between iRODS 3.x/4.0.x MD5 and
 // OpenSSL MD5. We just use whichever is present, which the ifdefs

--- a/src/irods_3_x_x.h
+++ b/src/irods_3_x_x.h
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2015 Genome Research Ltd. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @file irods_3_x_x.h
+ * @author Keith James <kdj@sanger.ac.uk>
+ */
+
+#ifndef _IRODS_3_X_X_H
+#define _IRODS_3_X_X_H
+
+#include "rodsClient.h"
+
+#include "md5Checksum.h"
+
+#endif // _IRODS_3_X_X_H

--- a/src/irods_4_0_x.h
+++ b/src/irods_4_0_x.h
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2015 Genome Research Ltd. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @file irods_4_0_x.h
+ * @author Keith James <kdj@sanger.ac.uk>
+ */
+
+#ifndef _IRODS_4_0_X_H
+#define _IRODS_4_0_X_H
+
+#include <rodsClient.hpp>
+
+#endif // _IRODS_4_0_X_H

--- a/src/irods_4_1_x.h
+++ b/src/irods_4_1_x.h
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2015 Genome Research Ltd. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @file irods_4_1_x.h
+ * @author Keith James <kdj@sanger.ac.uk>
+ */
+
+#ifndef _IRODS_4_1_X_H
+#define _IRODS_4_1_X_H
+
+#include <rodsClient.h>
+
+#include <openssl/md5.h>
+
+#endif // _IRODS_4_1_X_H

--- a/src/irods_api.h
+++ b/src/irods_api.h
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 Genome Research Ltd. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @file irods_api.h
+ * @author Keith James <kdj@sanger.ac.uk>
+ */
+
+#ifndef _IRODS_API_H
+#define _IRODS_API_H
+
+#include "config.h"
+
+#if HAVE_IRODS3
+#include "irods_3_x_x.h"
+#elif HAVE_IRODS4
+#include "irods_4_1_x.h"
+#endif
+
+#endif // _IRODS_API_H

--- a/src/json.c
+++ b/src/json.c
@@ -25,20 +25,9 @@
 #include <stdlib.h>
 #include <time.h>
 
-#include "config.h"
-
-#ifdef HAVE_IRODS3
-#include "rodsClient.h"
-#include "rodsErrorTable.h"
-#endif
-
-#ifdef HAVE_IRODS4
-#include "rodsClient.hpp"
-#include "rodsErrorTable.hpp"
-#endif
-
 #include <jansson.h>
 
+#include "config.h"
 #include "json.h"
 #include "log.h"
 #include "utilities.h"

--- a/src/json.h
+++ b/src/json.h
@@ -25,16 +25,8 @@
 #include <jansson.h>
 
 #include "config.h"
-
-#ifdef HAVE_IRODS3
-#include "rodsClient.h"
-#endif
-
-#ifdef HAVE_IRODS4
-#include "rodsClient.hpp"
-#endif
-
 #include "error.h"
+#include "irods_api.h"
 
 #define JSON_ERROR_KEY             "error"
 #define JSON_ERROR_CODE_KEY        "code"

--- a/src/json_query.c
+++ b/src/json_query.c
@@ -24,15 +24,6 @@
 #include <jansson.h>
 
 #include "config.h"
-
-#ifdef HAVE_IRODS3
-#include "rodsClient.h"
-#endif
-
-#ifdef HAVE_IRODS4
-#include "rodsClient.hpp"
-#endif
-
 #include "baton.h"
 #include "json.h"
 #include "json_query.h"

--- a/src/json_query.h
+++ b/src/json_query.h
@@ -25,16 +25,8 @@
 #include <jansson.h>
 
 #include "config.h"
-
-#ifdef HAVE_IRODS3
-#include "rodsClient.h"
-#endif
-
-#ifdef HAVE_IRODS4
-#include "rodsClient.hpp"
-#endif
-
 #include "error.h"
+#include "irods_api.h"
 #include "query.h"
 #include "utilities.h"
 

--- a/src/query.c
+++ b/src/query.c
@@ -26,15 +26,6 @@
 #include <string.h>
 
 #include "config.h"
-
-#ifdef HAVE_IRODS3
-#include "rodsClient.h"
-#endif
-
-#ifdef HAVE_IRODS4
-#include "rodsClient.hpp"
-#endif
-
 #include "log.h"
 #include "query.h"
 #include "utilities.h"

--- a/src/query.h
+++ b/src/query.h
@@ -23,15 +23,7 @@
 #define _BATON_QUERY_H
 
 #include "config.h"
-
-#ifdef HAVE_IRODS3
-#include "rodsClient.h"
-#endif
-
-#ifdef HAVE_IRODS4
-#include "rodsClient.hpp"
-#endif
-
+#include "irods_api.h"
 #include "log.h"
 #include "utilities.h"
 

--- a/src/read.c
+++ b/src/read.c
@@ -21,23 +21,7 @@
 #include <assert.h>
 
 #include "config.h"
-
-#ifdef HAVE_IRODS3
-#include "dataObjOpen.h"
-#include "dataObjRead.h"
-#include "dataObjChksum.h"
-#include "dataObjClose.h"
-#endif
-
-#ifdef HAVE_IRODS4
-#include "dataObjOpen.hpp"
-#include "dataObjRead.hpp"
-#include "dataObjChksum.hpp"
-#include "dataObjClose.hpp"
-#endif
-
 #include "compat_checksum.h"
-
 #include "error.h"
 #include "read.h"
 #include "utilities.h"

--- a/src/read.h
+++ b/src/read.h
@@ -22,20 +22,8 @@
 #define _READ_H
 
 #include "config.h"
-
-#ifdef HAVE_IRODS3
-#include "dataObjOpen.h"
-#include "dataObjRead.h"
-#include "dataObjClose.h"
-#endif
-
-#ifdef HAVE_IRODS4
-#include "dataObjOpen.hpp"
-#include "dataObjRead.hpp"
-#include "dataObjClose.hpp"
-#endif
-
 #include "error.h"
+#include "irods_api.h"
 #include "log.h"
 
 /**


### PR DESCRIPTION
Factored out iRODS version compatability headers.

Added irods_api.h and version-specific headers to include_HEADERS

Track iRODS' change back to .h headers.

Added schema validation (set to 'off' to disable validation).