### PR TITLE
Error handling refactor

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -24,12 +24,13 @@
 #include <string.h>
 
 #include "error.h"
+#include "log.h"
 
 void init_baton_error(baton_error_t *error) {
     assert(error);
     error->message[0] = '\0';
     error->code = 0;
-    error->size = 1;
+    error->size = 1; // Size includes terminating null byte.
 }
 
 void set_baton_error(baton_error_t *error, int code, const char *format, ...) {

--- a/src/error.h
+++ b/src/error.h
@@ -28,7 +28,7 @@ typedef struct baton_error {
     int code;
     /** Error message */
     char message[MAX_ERROR_MESSAGE_LEN];
-    /** Error message length */
+    /** Error message length, including terminating null byte */
     size_t size;
 } baton_error_t;
 

--- a/src/json.c
+++ b/src/json.c
@@ -261,6 +261,7 @@ const char *get_timestamp_operator(json_t *timestamp, baton_error_t *error) {
 
 int has_collection(json_t *object) {
     baton_error_t error;
+
     init_baton_error(&error); // Ignore error
 
     return get_opt_string_value(object, "path spec", JSON_COLLECTION_KEY,
@@ -273,6 +274,7 @@ int has_acl(json_t *object) {
 
 int has_timestamps(json_t *object) {
   baton_error_t error;
+
   init_baton_error(&error); // Ignore error
 
   return get_timestamps(object, &error) != NULL;
@@ -548,6 +550,7 @@ error:
 
 char *json_to_path(json_t *object, baton_error_t *error) {
     char *path = NULL;
+
     init_baton_error(error);
 
     const char *collection = get_collection_value(object, error);
@@ -573,6 +576,7 @@ error:
 
 char *json_to_collection_path(json_t *object, baton_error_t *error) {
     char *path = NULL;
+
     init_baton_error(error);
 
     const char *collection = get_collection_value(object, error);
@@ -591,6 +595,7 @@ error:
 
 char *json_to_local_path(json_t *object, baton_error_t *error) {
     char *path = NULL;
+
     init_baton_error(error);
 
     const char *directory = get_directory_value(object, error);

--- a/src/json_query.c
+++ b/src/json_query.c
@@ -192,10 +192,6 @@ json_t *do_query(rcComm_t *conn, genQueryInp_t *query_in,
     size_t chunk_num  = 0;
     int continue_flag = 0;
 
-    char *err_name;
-    char *err_subname;
-    int status;
-
     json_t *results = json_array();
     if (!results) {
         set_baton_error(error, -1, "Failed to allocate a new JSON array");
@@ -207,7 +203,7 @@ json_t *do_query(rcComm_t *conn, genQueryInp_t *query_in,
     while (chunk_num == 0 || continue_flag > 0) {
         logmsg(DEBUG, "Attempting to get chunk %d of query", chunk_num);
 
-        status = rcGenQuery(conn, query_in, &query_out);
+        int status = rcGenQuery(conn, query_in, &query_out);
 
         if (status == 0) {
             logmsg(DEBUG, "Successfully fetched chunk %d of query", chunk_num);
@@ -262,11 +258,11 @@ json_t *do_query(rcComm_t *conn, genQueryInp_t *query_in,
             break;
         }
         else {
-            err_name = rodsErrorName(status, &err_subname);
+            char *err_subname;
+            char *err_name = rodsErrorName(status, &err_subname);
             set_baton_error(error, status,
                             "Failed to fetch query result: in chunk %d "
-                            "error %d %s %s",
-                            chunk_num, status, err_name, err_subname);
+                            "error %d %s", chunk_num, status, err_name);
             goto error;
         }
     }
@@ -576,7 +572,6 @@ json_t *add_checksum_json_array(rcComm_t *conn, json_t *array,
     return array;
 
 error:
-    logmsg(ERROR, error->message);
     return NULL;
 }
 
@@ -640,7 +635,6 @@ json_t *add_repl_json_array(rcComm_t *conn, json_t *array,
     return array;
 
 error:
-    logmsg(ERROR, error->message);
     return NULL;
 }
 
@@ -757,7 +751,6 @@ json_t *add_tps_json_array(rcComm_t *conn, json_t *array,
     return array;
 
 error:
-    logmsg(ERROR, error->message);
     return NULL;
 }
 
@@ -819,7 +812,6 @@ json_t *add_avus_json_array(rcComm_t *conn, json_t *array,
     return array;
 
 error:
-    logmsg(ERROR, error->message);
     return NULL;
 }
 
@@ -881,7 +873,6 @@ json_t *add_acl_json_array(rcComm_t *conn, json_t *array,
     return array;
 
 error:
-    logmsg(ERROR, error->message);
     return NULL;
 }
 

--- a/src/read.c
+++ b/src/read.c
@@ -35,14 +35,14 @@ data_obj_file_t *open_data_obj(rcComm_t *conn, rodsPath_t *rods_path,
     logmsg(DEBUG, "Opening data object '%s'", rods_path->outPath);
 
     snprintf(obj_open_in.objPath, MAX_NAME_LEN, "%s", rods_path->outPath);
-    int descriptor = rcDataObjOpen(conn, &obj_open_in);
 
+    int descriptor = rcDataObjOpen(conn, &obj_open_in);
     if (descriptor < 0) {
         char *err_subname;
         char *err_name = rodsErrorName(descriptor, &err_subname);
         set_baton_error(error, descriptor,
-                        "Failed to open '%s': %s %s", rods_path->outPath,
-                        err_name, err_subname);
+                        "Failed to open '%s': error %d %s",
+                        rods_path->outPath, descriptor, err_name);
         goto error;
     }
 
@@ -86,8 +86,8 @@ size_t read_data_obj(rcComm_t *conn, data_obj_file_t *obj_file, char *buffer,
         char *err_subname;
         char *err_name = rodsErrorName(num_read, &err_subname);
         set_baton_error(error, num_read,
-                        "Failed to read up to %zu bytes from '%s': %s %s",
-                        len, obj_file->path, err_name, err_subname);
+                        "Failed to read up to %zu bytes from '%s': %s",
+                        len, obj_file->path, err_name);
         goto error;
     }
 


### PR DESCRIPTION
Pass through full error message where available.

Ignore error_subname as it is always empty.

Make error code more consistent. Reduced scope of some error message strings.

Fixes #123