### PR TITLE
Support for reporting replicates

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -368,6 +368,12 @@ Options
   Prints command line help.
 
 .. program:: baton-list
+.. option:: --replicate
+
+  Print data object replicate information, in the format described in
+  :ref:`representing_replicates`.
+
+.. program:: baton-list
 .. option:: --silent
 
    Silence error messages.
@@ -644,17 +650,6 @@ object checksums are given under the ``checksum`` property.
 
   {"collection:" "/unit/home/user", "data_object": "README.txt", "size": 123456}
 
-In cases where data objects have replicates, the full details of
-replication may be displayed, including replicate identity numbers,
-status (valid or invalid) and checksum.
-
-.. code-block:: json
-
-  {"collection": "/unit/home/user", "data_object": "README.txt",
-   "replicate": [{"checksum": "2ebec02316ddc3ee64a67c89b5e3140c",
-                 "number": 0,
-                 "valid": true}]}
-
 The above JSON representations of collections and data objects are
 sufficient to be passed to baton's ``baton-list`` program, which
 fulfils a similar role to the iRODS ``ils`` program, listing data
@@ -662,6 +657,24 @@ objects and collection contents.
 
 ``baton`` ignores JSON properties that it does not recognise, therefore it
 is harmless to include extra properties in program input.
+
+.. _representing_replicates:
+
+Representing replicates
+=======================
+
+In cases where data objects have replicates, the full details of
+replication may be displayed, including replicate identity numbers,
+status (valid or invalid), resource name, location and checksum.
+
+.. code-block:: json
+
+  {"collection": "/unit/home/user", "data_object": "README.txt",
+   "replicates": [{"checksum": "2ebec02316ddc3ee64a67c89b5e3140c",
+                   "location": "unit-a-1",
+                   "resource": "test_resource",
+                   "number": 0,
+                   "valid": true}]}
 
 .. _representing_local_paths:
 
@@ -913,7 +926,6 @@ modified in 2014-03, the syntax would be:
    {"timestamps": [{"created":  "2014-01-01T00:00:00", "operator": "n<"},
                    {"modified": "2014-03-01T00:00:00", "operator": "n>="},
                    {"modified": "2014-03-31T00:00:00", "operator": "n<"}]}
-
 
 .. _representing_permissions:
 

--- a/src/baton.c
+++ b/src/baton.c
@@ -986,13 +986,14 @@ json_t *list_replicates(rcComm_t *conn, rodsPath_t *rods_path,
     results = do_query(conn, query_in, obj_format.labels, error);
     if (error->code != 0) goto error;
 
-    results = revmap_replicate_results(results, error);
+    json_t *mapped = revmap_replicate_results(results, error);
     if (error->code != 0) goto error;
 
     logmsg(DEBUG, "Obtained replicates of '%s'", rods_path->outPath);
     free_query_input(query_in);
+    json_decref(results);
 
-    return results;
+    return mapped;
 
 error:
     logmsg(ERROR, "Failed to list replicates of '%s': error %d %s",

--- a/src/baton.c
+++ b/src/baton.c
@@ -223,9 +223,10 @@ error:
 
 int resolve_collection(json_t *object, rcComm_t *conn, rodsEnv *env,
                        option_flags flags, baton_error_t *error) {
+    char *collection = NULL;
+
     init_baton_error(error);
 
-    char *collection = NULL;
     if (!json_is_object(object)) {
         set_baton_error(error, -1, "Failed to resolve the iRODS collection: "
                         "target not a JSON object");
@@ -1013,6 +1014,8 @@ int modify_permissions(rcComm_t *conn, rodsPath_t *rods_path,
     modAccessControlInp_t mod_perms_in;
     int status;
 
+    init_baton_error(error);
+
     check_str_arg("owner specifier", owner_specifier, MAX_STR_LEN, error);
     if (error->code != 0) goto error;
 
@@ -1298,8 +1301,6 @@ static json_t *list_data_object(rcComm_t *conn, rodsPath_t *rods_path,
               .labels      = { JSON_COLLECTION_KEY, JSON_DATA_OBJECT_KEY } };
     }
 
-    init_baton_error(error);
-
     query_in = make_query_input(SEARCH_MAX_ROWS, obj_format->num_columns,
                                 obj_format->columns);
     query_in = prepare_obj_list(query_in, rods_path, NULL);
@@ -1337,11 +1338,11 @@ error:
 
 static json_t *list_collection(rcComm_t *conn, rodsPath_t *rods_path,
                                option_flags flags, baton_error_t *error) {
+    json_t *results = NULL;
+
     int query_flags = DATA_QUERY_FIRST_FG;
     collHandle_t coll_handle;
     collEnt_t coll_entry;
-
-    json_t *results = NULL;
 
     int status = rclOpenCollection(conn, rods_path->outPath, query_flags,
                                    &coll_handle);

--- a/src/json.c
+++ b/src/json.c
@@ -330,7 +330,7 @@ int represents_file(json_t *object) {
 }
 
 json_t *make_timestamp(const char* key, const char *value, const char *format,
-                       int *repl_num, baton_error_t *error) {
+                       const char *repl_num, baton_error_t *error) {
     char *formatted = format_timestamp(value, format);
 
     json_t *result = json_pack("{s:s}", key, formatted);
@@ -342,8 +342,17 @@ json_t *make_timestamp(const char* key, const char *value, const char *format,
     }
 
     if (repl_num) {
-        json_object_set_new(result, JSON_REPLICATE_KEY,
-                            json_integer(*repl_num));
+        int base = 10;
+        char *endptr;
+        int repl = strtoul(repl_num, &endptr, base);
+        if (*endptr) {
+            set_baton_error(error, -1,
+                            "Failed to parse replicate number from "
+                            "string '%s'", repl_num);
+            goto error;
+        }
+
+        json_object_set_new(result, JSON_REPLICATE_KEY, json_integer(repl));
     }
 
     free(formatted);
@@ -357,7 +366,7 @@ error:
 }
 
 int add_timestamps(json_t *object, const char *created, const char *modified,
-                   int *repl_num, baton_error_t *error) {
+                   const char *repl_num, baton_error_t *error) {
     json_t *iso_created  = NULL;
     json_t *iso_modified = NULL;
     json_t *timestamps;

--- a/src/json.c
+++ b/src/json.c
@@ -367,8 +367,8 @@ error:
 }
 
 json_t *make_replicate(const char *resource, const char *location,
-                       const char *replicate, const char *status,
-                       baton_error_t *error) {
+                       const char *checksum, const char *replicate,
+                       const char *status, baton_error_t *error) {
     json_t *result   = NULL;
     json_t *is_valid = NULL;
 
@@ -394,9 +394,10 @@ json_t *make_replicate(const char *resource, const char *location,
         goto error;
     }
 
-    result = json_pack("{s:s, s:s, s:i, s:o}",
+    result = json_pack("{s:s, s:s, s:s, s:i, s:o}",
                        JSON_RESOURCE_KEY,         resource,
                        JSON_LOCATION_KEY,         location,
+                       JSON_CHECKSUM_KEY,         checksum,
                        JSON_REPLICATE_NUMBER_KEY, repl,
                        JSON_REPLICATE_STATUS_KEY, is_valid);
     if (!result) {

--- a/src/json.c
+++ b/src/json.c
@@ -71,6 +71,8 @@ int add_error_value(json_t *object, baton_error_t *error) {
 }
 
 json_t *get_acl(json_t *object, baton_error_t *error) {
+    init_baton_error(error);
+
     json_t *acl = get_json_value(object, "path spec", JSON_ACCESS_KEY, NULL,
                                  error);
     if (error->code != 0) goto error;
@@ -88,6 +90,8 @@ error:
 }
 
 json_t *get_avus(json_t *object, baton_error_t *error) {
+    init_baton_error(error);
+
     json_t *avus = get_json_value(object, "path spec", JSON_AVUS_KEY, NULL,
                                   error);
     if (error->code != 0) goto error;
@@ -105,6 +109,8 @@ error:
 }
 
 json_t *get_timestamps(json_t *object, baton_error_t *error) {
+    init_baton_error(error);
+
     json_t *timestamps = get_json_value(object, "path spec",
                                         JSON_TIMESTAMPS_KEY,
                                         JSON_TIMESTAMPS_SHORT_KEY, error);
@@ -123,57 +129,80 @@ error:
 }
 
 const char *get_collection_value(json_t *object, baton_error_t *error) {
+    init_baton_error(error);
+
     return get_string_value(object, "path spec", JSON_COLLECTION_KEY,
                             JSON_COLLECTION_SHORT_KEY, error);
 }
 
 const char *get_data_object_value(json_t *object, baton_error_t *error) {
+    init_baton_error(error);
+
     return get_opt_string_value(object, "path spec", JSON_DATA_OBJECT_KEY,
                                 JSON_DATA_OBJECT_SHORT_KEY, error);
 }
 
 const char *get_directory_value(json_t *object, baton_error_t *error) {
+    init_baton_error(error);
+
     return get_opt_string_value(object, "path spec", JSON_DIRECTORY_KEY,
                                 JSON_DIRECTORY_SHORT_KEY, error);
 }
 
 const char *get_file_value(json_t *object, baton_error_t *error) {
+    init_baton_error(error);
+
     return get_opt_string_value(object, "path spec", JSON_FILE_KEY,
                                 NULL, error);
 }
 
 const char *get_query_collection(json_t *object, baton_error_t *error) {
+    init_baton_error(error);
+
     return get_opt_string_value(object, "path spec", JSON_COLLECTION_KEY,
                                 JSON_COLLECTION_SHORT_KEY, error);
 }
 
 const char *get_created_timestamp(json_t *object, baton_error_t *error) {
+    init_baton_error(error);
+
     return get_string_value(object, "timestamps", JSON_CREATED_KEY,
                             JSON_CREATED_SHORT_KEY, error);
 }
 
 const char *get_modified_timestamp(json_t *object, baton_error_t *error) {
+    init_baton_error(error);
+
     return get_string_value(object, "timestamps", JSON_MODIFIED_KEY,
                             JSON_MODIFIED_SHORT_KEY, error);
 }
 
 const char *get_replicate_num(json_t *object, baton_error_t *error) {
+    init_baton_error(error);
+
     return get_opt_string_value(object, "timestamps", JSON_REPLICATE_KEY,
                                 JSON_REPLICATE_SHORT_KEY, error);
 }
 
 const char *get_avu_attribute(json_t *avu, baton_error_t *error) {
+    init_baton_error(error);
+
     return get_string_value(avu, "AVU", JSON_ATTRIBUTE_KEY,
                             JSON_ATTRIBUTE_SHORT_KEY, error);
 }
 
 const char *get_avu_value(json_t *avu, baton_error_t *error) {
+    init_baton_error(error);
+
     return get_string_value(avu, "AVU", JSON_VALUE_KEY,
                             JSON_VALUE_SHORT_KEY, error);
 }
 
 char *make_in_op_value(json_t *avu, baton_error_t *error) {
     json_t *op_value = NULL;
+
+    init_baton_error(error);
+
     json_t *valarray = get_json_value(avu, "value", JSON_VALUE_KEY,
                                       JSON_VALUE_SHORT_KEY, error);
     if (error->code != 0) goto error;
@@ -238,24 +267,34 @@ error:
 }
 
 const char *get_avu_units(json_t *avu, baton_error_t *error) {
+    init_baton_error(error);
+
     return get_opt_string_value(avu, "AVU", JSON_UNITS_KEY,
                                 JSON_UNITS_SHORT_KEY, error);
 }
 
 const char *get_avu_operator(json_t *avu, baton_error_t *error) {
+    init_baton_error(error);
+
     return get_opt_string_value(avu, "AVU", JSON_OPERATOR_KEY,
                                 JSON_OPERATOR_SHORT_KEY, error);
 }
 
 const char *get_access_owner(json_t *access, baton_error_t *error) {
+    init_baton_error(error);
+
     return get_string_value(access, "access spec", JSON_OWNER_KEY, NULL, error);
 }
 
 const char *get_access_level(json_t *access, baton_error_t *error) {
+    init_baton_error(error);
+
     return get_string_value(access, "access spec", JSON_LEVEL_KEY, NULL, error);
 }
 
 const char *get_timestamp_operator(json_t *timestamp, baton_error_t *error) {
+    init_baton_error(error);
+
     return get_opt_string_value(timestamp, "timestamp", JSON_OPERATOR_KEY,
                                 JSON_OPERATOR_SHORT_KEY, error);
 }
@@ -332,8 +371,9 @@ int represents_file(json_t *object) {
 
 json_t *make_timestamp(const char* key, const char *value, const char *format,
                        const char *replicate, baton_error_t *error) {
-    char *formatted = format_timestamp(value, format);
+    init_baton_error(error);
 
+    char *formatted = format_timestamp(value, format);
     json_t *result = json_pack("{s:s}", key, formatted);
     if (!result) {
         set_baton_error(error, -1,
@@ -371,6 +411,8 @@ json_t *make_replicate(const char *resource, const char *location,
                        const char *status, baton_error_t *error) {
     json_t *result   = NULL;
     json_t *is_valid = NULL;
+
+    init_baton_error(error);
 
     int base = 10;
     char *endptr;
@@ -420,6 +462,8 @@ int add_timestamps(json_t *object, const char *created, const char *modified,
     json_t *iso_modified = NULL;
     json_t *timestamps;
 
+    init_baton_error(error);
+
     if (!json_is_object(object)) {
         set_baton_error(error, -1, "Failed to add timestamp data: "
                         "target not a JSON object");
@@ -447,6 +491,8 @@ error:
 }
 
 int add_replicates(json_t *object, json_t *replicates, baton_error_t *error) {
+    init_baton_error(error);
+
     if (!json_is_object(object)) {
         set_baton_error(error, -1, "Failed to add replicates data: "
                         "target not a JSON object");
@@ -460,6 +506,8 @@ error:
 }
 
 int add_checksum(json_t *object, json_t *checksum, baton_error_t *error) {
+    init_baton_error(error);
+
     if (!json_is_object(object)) {
         set_baton_error(error, -1, "Failed to add checksum data: "
                         "target not a JSON object");
@@ -474,6 +522,8 @@ error:
 
 int add_collection(json_t *object, const char *coll_name,
                    baton_error_t *error) {
+    init_baton_error(error);
+
     if (!json_is_object(object)) {
         set_baton_error(error, -1, "Failed to add collection data: "
                         "target not a JSON object");
@@ -494,6 +544,8 @@ error:
 }
 
 int add_metadata(json_t *object, json_t *avus, baton_error_t *error) {
+    init_baton_error(error);
+
     if (!json_is_object(object)) {
         set_baton_error(error, -1, "Failed to add AVU data: "
                         "target not a JSON object");
@@ -507,6 +559,8 @@ error:
 }
 
 int add_permissions(json_t *object, json_t *perms, baton_error_t *error) {
+    init_baton_error(error);
+
     if (!json_is_object(object)) {
         set_baton_error(error, -1, "Failed to add permissions data: "
                         "target not a JSON object");
@@ -520,13 +574,15 @@ error:
 }
 
 int add_contents(json_t *object, json_t *contents, baton_error_t *error) {
-  if (!json_is_object(object)) {
-      set_baton_error(error, -1, "Failed to add contents data: "
-                      "target not a JSON object");
-      goto error;
-  }
+    init_baton_error(error);
 
-  return json_object_set_new(object, JSON_CONTENTS_KEY, contents);
+    if (!json_is_object(object)) {
+        set_baton_error(error, -1, "Failed to add contents data: "
+                        "target not a JSON object");
+        goto error;
+    }
+
+    return json_object_set_new(object, JSON_CONTENTS_KEY, contents);
 
 error:
     return error->code;
@@ -535,6 +591,8 @@ error:
 json_t *data_object_parts_to_json(const char *coll_name,
                                   const char *data_name,
                                   baton_error_t *error) {
+    init_baton_error(error);
+
     json_t *result = json_pack("{s:s, s:s}",
                                JSON_COLLECTION_KEY,  coll_name,
                                JSON_DATA_OBJECT_KEY, data_name);
@@ -555,6 +613,8 @@ json_t *data_object_path_to_json(const char *path, baton_error_t *error) {
     char path2[MAX_STR_LEN];
     char *coll_name;
     char *data_name;
+
+    init_baton_error(error);
 
     size_t term_len = strnlen(path, MAX_STR_LEN) + 1;
     if (term_len > MAX_STR_LEN) {
@@ -593,6 +653,8 @@ error:
 }
 
 json_t *collection_path_to_json(const char *path, baton_error_t *error) {
+    init_baton_error(error);
+
     json_t *result = json_pack("{s:s}", JSON_COLLECTION_KEY, path);
     if (!result) {
         set_baton_error(error, -1, "Failed to pack collection '%s' as JSON",
@@ -781,6 +843,7 @@ static const char *get_opt_string_value(json_t *object, const char *name,
                                         const char *key, const char *short_key,
                                         baton_error_t *error) {
     const char *str = NULL;
+
     json_t *value;
     if (!json_is_object(object)) {
         set_baton_error(error, CAT_INVALID_ARGUMENT,

--- a/src/json.h
+++ b/src/json.h
@@ -193,8 +193,8 @@ json_t *make_timestamp(const char* key, const char *value, const char *format,
                        const char *replicate, baton_error_t *error);
 
 json_t *make_replicate(const char *resource, const char *location,
-                       const char *replicate, const char *status,
-                       baton_error_t *error);
+                       const char *checksum, const char *replicate,
+                       const char *status, baton_error_t *error);
 
 json_t *data_object_parts_to_json(const char *coll_name, const char *data_name,
                                   baton_error_t *error);

--- a/src/json.h
+++ b/src/json.h
@@ -38,7 +38,7 @@
 #define JSON_COLLECTION_SHORT_KEY  "coll"
 #define JSON_TIMESTAMPS_KEY        "timestamps"
 #define JSON_TIMESTAMPS_SHORT_KEY  "time"
-#define JSON_REPLICATE_KEY         "replicate"
+#define JSON_REPLICATE_KEY         "replicates"
 #define JSON_REPLICATE_SHORT_KEY   "rep"
 #define JSON_REPLICATE_NUMBER_KEY  "number"
 #define JSON_REPLICATE_STATUS_KEY  "valid"

--- a/src/json.h
+++ b/src/json.h
@@ -181,7 +181,7 @@ int add_permissions(json_t *object, json_t *perms, baton_error_t *error);
 int add_contents(json_t *object, json_t *contents, baton_error_t *error);
 
 int add_timestamps(json_t *object, const char *created, const char *modified,
-                   const char *repl_num, baton_error_t *error);
+                   const char *replicate, baton_error_t *error);
 
 int add_replicates(json_t *object, json_t *replicates, baton_error_t *error);
 
@@ -190,7 +190,11 @@ int add_checksum(json_t *object, json_t *checksum, baton_error_t *error);
 int add_error_report(json_t *target, baton_error_t *error);
 
 json_t *make_timestamp(const char* key, const char *value, const char *format,
-                       const char *repl_num, baton_error_t *error);
+                       const char *replicate, baton_error_t *error);
+
+json_t *make_replicate(const char *resource, const char *location,
+                       const char *replicate, const char *status,
+                       baton_error_t *error);
 
 json_t *data_object_parts_to_json(const char *coll_name, const char *data_name,
                                   baton_error_t *error);

--- a/src/json.h
+++ b/src/json.h
@@ -181,7 +181,7 @@ int add_permissions(json_t *object, json_t *perms, baton_error_t *error);
 int add_contents(json_t *object, json_t *contents, baton_error_t *error);
 
 int add_timestamps(json_t *object, const char *created, const char *modified,
-                   int *repl_num, baton_error_t *error);
+                   const char *repl_num, baton_error_t *error);
 
 int add_replicates(json_t *object, json_t *replicates, baton_error_t *error);
 
@@ -190,7 +190,7 @@ int add_checksum(json_t *object, json_t *checksum, baton_error_t *error);
 int add_error_report(json_t *target, baton_error_t *error);
 
 json_t *make_timestamp(const char* key, const char *value, const char *format,
-                       int *repl_num, baton_error_t *error);
+                       const char *repl_num, baton_error_t *error);
 
 json_t *data_object_parts_to_json(const char *coll_name, const char *data_name,
                                   baton_error_t *error);

--- a/src/json_query.c
+++ b/src/json_query.c
@@ -673,22 +673,11 @@ json_t *add_tps_json_object(rcComm_t *conn, json_t *object,
     // collections too, but we don't report them to be consistent with
     // the 'ils' command.
     if (represents_data_object(object)) {
-        int base = 10;
         size_t i;
         json_t *item;
         json_array_foreach(raw_timestamps, i, item) {
-            const char *repl_str = get_replicate_num(item, error);
+            const char *repl_num = get_replicate_num(item, error);
             if (error->code != 0) goto error;
-
-            char *endptr;
-            int repl_num = strtoul(repl_str, &endptr, base);
-            if (*endptr) {
-                set_baton_error(error, -1,
-                                "Failed to parse replicate number from "
-                                "string '%s'", repl_str);
-                goto error;
-            }
-
             const char *created = get_created_timestamp(item, error);
             if (error->code != 0) goto error;
             const char *modified = get_modified_timestamp(item, error);
@@ -696,18 +685,18 @@ json_t *add_tps_json_object(rcComm_t *conn, json_t *object,
 
             json_t *iso_created =
                 make_timestamp(JSON_CREATED_KEY, created, ISO8601_FORMAT,
-                               &repl_num, error);
+                               repl_num, error);
             if (error->code != 0) goto error;
 
             json_t *iso_modified =
                 make_timestamp(JSON_MODIFIED_KEY, modified, ISO8601_FORMAT,
-                               &repl_num, error);
+                               repl_num, error);
             if (error->code != 0) goto error;
 
             json_array_append_new(timestamps, iso_created);
             json_array_append_new(timestamps, iso_modified);
 
-            logmsg(DEBUG, "Adding timestamps from replicate %d of '%s'",
+            logmsg(DEBUG, "Adding timestamps from replicate %s of '%s'",
                    repl_num, path);
         }
     }

--- a/src/json_query.c
+++ b/src/json_query.c
@@ -55,6 +55,8 @@ const char *ensure_valid_operator(const char *oper, baton_error_t *error) {
                                  SEARCH_OP_NUM_GT,   SEARCH_OP_NUM_LT,
                                  SEARCH_OP_STR_GE,   SEARCH_OP_STR_LE,
                                  SEARCH_OP_NUM_GE,   SEARCH_OP_NUM_LE };
+    init_baton_error(error);
+
     size_t valid_index;
     int valid = 0;
     for (size_t i = 0; i < num_operators; i++) {
@@ -96,6 +98,8 @@ json_t *do_search(rcComm_t *conn, char *zone_name, json_t *query,
     char *root_path         = NULL;
     json_t *items           = NULL;
     json_t *avus;
+
+    init_baton_error(error);
 
     if (represents_collection(query)) {
         root_path = json_to_path(query, error);
@@ -191,6 +195,8 @@ json_t *do_query(rcComm_t *conn, genQueryInp_t *query_in,
     genQueryOut_t *query_out = NULL;
     size_t chunk_num  = 0;
     int continue_flag = 0;
+
+    init_baton_error(error);
 
     json_t *results = json_array();
     if (!results) {
@@ -355,6 +361,9 @@ genQueryInp_t *prepare_json_acl_search(genQueryInp_t *query_in,
                                        prepare_acl_search_cb prepare,
                                        baton_error_t *error) {
     size_t num_clauses = json_array_size(mapped_acl);
+
+    init_baton_error(error);
+
     if (num_clauses > 1) {
         set_baton_error(error, -1,
                         "Invalid permissions specification "
@@ -395,8 +404,10 @@ genQueryInp_t *prepare_json_avu_search(genQueryInp_t *query_in,
                                        prepare_avu_search_cb prepare,
                                        baton_error_t *error) {
     json_t *in_opvalue = NULL;
-    size_t num_clauses = json_array_size(avus);
 
+    init_baton_error(error);
+
+    size_t num_clauses = json_array_size(avus);
     size_t i;
     json_t *avu;
     json_array_foreach(avus, i, avu) {
@@ -453,6 +464,8 @@ genQueryInp_t *prepare_json_tps_search(genQueryInp_t *query_in,
                                        prepare_tps_search_cb prepare_cre,
                                        prepare_tps_search_cb prepare_mod,
                                        baton_error_t *error) {
+    init_baton_error(error);
+
     size_t num_clauses = json_array_size(timestamps);
 
     size_t i;
@@ -519,6 +532,8 @@ json_t *add_checksum_json_object(rcComm_t *conn, json_t *object,
     json_t *checksum;
     int status;
 
+    init_baton_error(error);
+
     if (!json_is_object(object)) {
         set_baton_error(error, CAT_INVALID_ARGUMENT,
                         "Invalid target: not a JSON object");
@@ -582,6 +597,8 @@ json_t *add_repl_json_object(rcComm_t *conn, json_t *object,
     json_t *replicates;
     int status;
 
+    init_baton_error(error);
+
     if (!json_is_object(object)) {
         set_baton_error(error, CAT_INVALID_ARGUMENT,
                         "Invalid target: not a JSON object");
@@ -617,6 +634,8 @@ error:
 
 json_t *add_repl_json_array(rcComm_t *conn, json_t *array,
                             baton_error_t *error) {
+    init_baton_error(error);
+
     if (!json_is_array(array)) {
         set_baton_error(error, CAT_INVALID_ARGUMENT,
                         "Invalid target: not a JSON array");
@@ -644,6 +663,8 @@ json_t *add_tps_json_object(rcComm_t *conn, json_t *object,
     char *path             = NULL;
     json_t *raw_timestamps = NULL;
     json_t *timestamps     = NULL;
+
+    init_baton_error(error);
 
     if (!json_is_object(object)) {
         set_baton_error(error, CAT_INVALID_ARGUMENT,
@@ -722,6 +743,8 @@ error:
 
 json_t *add_tps_json_array(rcComm_t *conn, json_t *array,
                            baton_error_t *error) {
+    init_baton_error(error);
+
     if (!json_is_array(array)) {
         set_baton_error(error, CAT_INVALID_ARGUMENT,
                         "Invalid target: not a JSON array");
@@ -749,6 +772,8 @@ json_t *add_avus_json_object(rcComm_t *conn, json_t *object,
     rodsPath_t rods_path;
     json_t *avus;
     int status;
+
+    init_baton_error(error);
 
     if (!json_is_object(object)) {
         set_baton_error(error, CAT_INVALID_ARGUMENT,
@@ -785,6 +810,8 @@ error:
 
 json_t *add_avus_json_array(rcComm_t *conn, json_t *array,
                             baton_error_t *error) {
+    init_baton_error(error);
+
     if (!json_is_array(array)) {
         set_baton_error(error, CAT_INVALID_ARGUMENT,
                         "Invalid target: not a JSON array");
@@ -810,6 +837,8 @@ json_t *add_acl_json_object(rcComm_t *conn, json_t *object,
     rodsPath_t rods_path;
     json_t *perms;
     int status;
+
+    init_baton_error(error);
 
     if (!json_is_object(object)) {
         set_baton_error(error, CAT_INVALID_ARGUMENT,
@@ -846,6 +875,8 @@ error:
 
 json_t *add_acl_json_array(rcComm_t *conn, json_t *array,
                            baton_error_t *error) {
+    init_baton_error(error);
+
     if (!json_is_array(array)) {
         set_baton_error(error, CAT_INVALID_ARGUMENT,
                         "Invalid target: not a JSON array");
@@ -913,6 +944,8 @@ static size_t parse_attr_value(int column, const char *label,
 json_t *map_access_args(json_t *query, baton_error_t *error) {
     json_t *user_info = NULL;
 
+    init_baton_error(error);
+
     if (has_acl(query)) {
         json_t *acl = get_acl(query, error);
         if (error->code != 0) goto error;
@@ -954,6 +987,8 @@ error:
 json_t *revmap_access_result(json_t *acl,  baton_error_t *error) {
     size_t num_elts;
 
+    init_baton_error(error);
+
     if (!json_is_array(acl)) {
         set_baton_error(error, CAT_INVALID_ARGUMENT,
                         "Invalid ACL: not a JSON array");
@@ -984,6 +1019,8 @@ error:
 }
 
 json_t *revmap_replicate_results(json_t *results, baton_error_t *error) {
+    init_baton_error(error);
+
     json_t *mapped = json_array();
 
     size_t num_elts = json_array_size(results);

--- a/src/read.c
+++ b/src/read.c
@@ -29,6 +29,9 @@
 data_obj_file_t *open_data_obj(rcComm_t *conn, rodsPath_t *rods_path,
                                baton_error_t *error) {
     dataObjInp_t obj_open_in;
+
+    init_baton_error(error);
+
     memset(&obj_open_in, 0, sizeof obj_open_in);
     obj_open_in.openFlags = O_RDONLY;
 
@@ -70,6 +73,9 @@ error:
 size_t read_data_obj(rcComm_t *conn, data_obj_file_t *obj_file, char *buffer,
                      size_t len, baton_error_t *error) {
     openedDataObjInp_t obj_read_in;
+
+    init_baton_error(error);
+
     memset(&obj_read_in, 0, sizeof obj_read_in);
     obj_read_in.l1descInx = obj_file->descriptor;
     obj_read_in.len       = len;
@@ -103,6 +109,8 @@ char *slurp_data_object(rcComm_t *conn, data_obj_file_t *obj_file,
                         size_t buffer_size, baton_error_t *error) {
     char *buffer  = NULL;
     char *content = NULL;
+
+    init_baton_error(error);
 
     buffer = calloc(buffer_size +1, sizeof (char));
     if (!buffer) {
@@ -179,6 +187,8 @@ size_t stream_data_object(rcComm_t *conn, data_obj_file_t *obj_file, FILE *out,
                           size_t buffer_size, baton_error_t *error) {
     size_t num_written = 0;
     char *buffer = NULL;
+
+    init_baton_error(error);
 
     if (buffer_size == 0) {
         set_baton_error(error, -1, "Invalid buffer_size argument %u",

--- a/tests/check_baton.c
+++ b/tests/check_baton.c
@@ -645,9 +645,6 @@ START_TEST(test_list_permissions_obj) {
                                  JSON_ZONE_KEY,  env.rodsZone,
                                  JSON_LEVEL_KEY, ACCESS_OWN);
 
-    print_json_stream(expected, stderr);
-    print_json_stream(results, stderr);
-
     ck_assert_int_eq(json_equal(results, expected), 1);
     ck_assert_int_eq(error.code, 0);
 
@@ -1050,7 +1047,6 @@ START_TEST(test_search_metadata_perm_obj) {
                                        flags, &resolve_error), EXIST_ST);
 
     baton_error_t mod_error;
-    init_baton_error(&mod_error);
     int rv = modify_permissions(conn, &rods_path, NO_RECURSE, "public",
                                 ACCESS_LEVEL_READ, &mod_error);
     ck_assert_int_eq(rv, 0);
@@ -1255,7 +1251,6 @@ START_TEST(test_add_metadata_obj) {
     ck_assert_int_ne(expected_error4.code, 0);
 
     baton_error_t error;
-    init_baton_error(&error);
     int rv = modify_metadata(conn, &rods_path, META_ADD, "test_attr",
                              "test_value", "test_units",
                              &error);
@@ -1318,7 +1313,6 @@ START_TEST(test_remove_metadata_obj) {
                                        flags, &resolve_error), EXIST_ST);
 
     baton_error_t error;
-    init_baton_error(&error);
     int rv = modify_metadata(conn, &rods_path, META_REM, "attr1", "value1",
                              "units1", &error);
     ck_assert_int_eq(rv, 0);
@@ -1461,7 +1455,6 @@ START_TEST(test_modify_permissions_obj) {
                                        flags, &resolve_error), EXIST_ST);
 
     baton_error_t mod_error;
-    init_baton_error(&mod_error);
     int rv = modify_permissions(conn, &rods_path, NO_RECURSE, "public",
                                 ACCESS_LEVEL_READ, &mod_error);
     ck_assert_int_eq(rv, 0);
@@ -1815,15 +1808,11 @@ START_TEST(test_slurp_file) {
                                 2048, 4096, 8192, 16384, 37268 };
     for (int i = 0; i < 10; i++) {
         baton_error_t open_error;
-        init_baton_error(&open_error);
-
-        data_obj_file_t *obj_file =
-            open_data_obj(conn, &rods_obj_path, &open_error);
+        data_obj_file_t *obj_file = open_data_obj(conn, &rods_obj_path,
+                                                  &open_error);
         ck_assert_int_eq(open_error.code, 0);
 
         baton_error_t slurp_error;
-        init_baton_error(&slurp_error);
-
         char *data = slurp_data_object(conn, obj_file, buffer_sizes[i],
                                        &slurp_error);
         ck_assert_int_eq(slurp_error.code, 0);


### PR DESCRIPTION
This code is slower than it could be (replicate reporting for a whole collection may be converted to a pairs of GenQuery calls, which will be faster).