### PR TITLE
use m4_esyscmd_s to avoid piping to tr and use subaddressing in email

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([baton], m4_esyscmd([git describe --dirty | tr -d '\012']), [kdj@sanger.ac.uk])
+AC_INIT([baton], m4_esyscmd_s([git describe --dirty --always --tags]), [kdj+baton@sanger.ac.uk])
 
 AC_PREREQ(2.68)
 AC_USE_SYSTEM_EXTENSIONS


### PR DESCRIPTION
Really minor configure.ac tweak suggestions....