### PR TITLE
hostname length workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ language: c
 compiler: gcc
 
 addons:
-  hosts:
-    - baton-ci
-
-addons:
   postgresql: "9.3"
 
 env:
@@ -25,6 +21,12 @@ env:
     - IRODS_VERSION=4.1.6
 
 before_install:
+  # workaround for iRODS buffer overflow
+  # see https://github.com/travis-ci/travis-ci/issues/5227
+  - cat /etc/hosts # optionally check the content *before*
+  - sudo hostname "$(hostname | cut -c1-63)"
+  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+  - cat /etc/hosts # optionally check the content *after*
   - ./scripts/travis_before_install.sh
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 
-sudo:
-  required
-
-dist:
-  precise
-
 language: c
 
 compiler: gcc
+
+addons:
+  hosts:
+    - baton-ci
 
 addons:
   postgresql: "9.3"
@@ -24,7 +22,7 @@ env:
     - PG_PLUGIN_VERSION=1.6
   matrix:
     - IRODS_VERSION=3.3.1
-#    - IRODS_VERSION=4.1.6
+    - IRODS_VERSION=4.1.6
 
 before_install:
   - ./scripts/travis_before_install.sh


### PR DESCRIPTION
This workaround was originally suggested for a JDK hostname buffer overflow in  travis-ci/travis-ci#5227. It resolves the iRODS 4.x FQDN buffer overflow too.