### PR TITLE
Allow a zone to be passed explicitly for chmod

### DIFF
--- a/src/baton.c
+++ b/src/baton.c
@@ -1138,18 +1138,27 @@ int modify_json_permissions(rcComm_t *conn, rodsPath_t *rods_path,
     char owner_specifier[LONG_NAME_LEN] = { 0 };
     char access_level[LONG_NAME_LEN]    = { 0 };
     const char *owner;
+    const char *zone = NULL;
     const char *level;
 
     init_baton_error(error);
 
+    zone = get_access_zone(access, error);
     owner = get_access_owner(access, error);
     if (error->code != 0) goto error;
 
+    if (zone) {
+        snprintf(owner_specifier, sizeof owner_specifier, "%s#%s",
+                 owner, zone);
+    }
+    else {
+        snprintf(owner_specifier, sizeof owner_specifier, "%s", owner);
+    }
+
     level = get_access_level(access, error);
+    snprintf(access_level, sizeof access_level, "%s", level);
     if (error->code != 0) goto error;
 
-    snprintf(owner_specifier, sizeof owner_specifier, "%s", owner);
-    snprintf(access_level, sizeof access_level, "%s", level);
 
     modify_permissions(conn, rods_path, recurse, owner_specifier,
                        access_level, error);

--- a/src/json.c
+++ b/src/json.c
@@ -323,6 +323,13 @@ const char *get_access_level(json_t *access, baton_error_t *error) {
     return get_string_value(access, "access spec", JSON_LEVEL_KEY, NULL, error);
 }
 
+const char *get_access_zone(json_t *access, baton_error_t *error) {
+    init_baton_error(error);
+
+    return get_opt_string_value(access, "access spec", JSON_ZONE_KEY,
+                                NULL, error);
+}
+
 const char *get_timestamp_operator(json_t *timestamp, baton_error_t *error) {
     init_baton_error(error);
 

--- a/src/json.h
+++ b/src/json.h
@@ -182,6 +182,8 @@ const char *get_access_owner(json_t *access, baton_error_t *error);
 
 const char *get_access_level(json_t *access, baton_error_t *error);
 
+const char *get_access_zone(json_t *access, baton_error_t *error);
+
 const char *get_timestamp_operator(json_t *timestamp, baton_error_t *error);
 
 int has_collection(json_t *object);


### PR DESCRIPTION
Allow a zone to be passed explicitly for chmod, making the input and output JSON identical for the operation.