### PR TITLE
Bug fix: the correct code may not returned when getting iRODS object types

### DIFF
--- a/src/baton.h
+++ b/src/baton.h
@@ -166,14 +166,15 @@ int resolve_rods_path(rcComm_t *conn, rodsEnv *env,
  * inPath and outPath and then resolving it on the server. The path is not
  * parsed, so must be derived from an existing parsed path.
  *
- * @param[in]  conn      An open iRODS connection.
- * @param[in]  env       A populated iRODS environment.
- * @param[out] rodspath  An iRODS path.
- * @param[in]  path      A string representing an unresolved iRODS path.
+ * @param[in]  conn     An open iRODS connection.
+ * @param[out] rodspath An iRODS path.
+ * @param[in]  path     A string representing an unresolved iRODS path.
+ * @param[out] error    An error report struct.
  *
  * @return 0 on success, iRODS error code on failure.
  */
-int set_rods_path(rcComm_t *conn, rodsPath_t *rods_path, char *path);
+int set_rods_path(rcComm_t *conn, rodsPath_t *rods_path, char *path,
+                  baton_error_t *error);
 
 int resolve_collection(json_t *object, rcComm_t *conn, rodsEnv *env,
                        option_flags flags, baton_error_t *error);

--- a/src/json.c
+++ b/src/json.c
@@ -979,8 +979,10 @@ static int has_json_str_value(json_t *object, const char *key,
 }
 
 static char *make_dir_path(const char *path, baton_error_t *error) {
-    size_t dlen = strnlen(path, MAX_STR_LEN) + 1; // +1 for NUL
-    if (str_ends_with(path, "/", MAX_STR_LEN)) {
+    size_t slen = strnlen(path, MAX_STR_LEN);
+    size_t dlen = slen + 1; // +1 for NUL
+    // Only trim trailing '/' if the path is >1 character long
+    if (slen > 1 && str_ends_with(path, "/", MAX_STR_LEN)) {
         dlen--;
     }
 

--- a/src/json_query.c
+++ b/src/json_query.c
@@ -114,12 +114,8 @@ json_t *do_search(rcComm_t *conn, char *zone_name, json_t *query,
     if (root_path) {
         rodsPath_t rods_path;
 
-        int status = set_rods_path(conn, &rods_path, root_path);
-        if (status < 0) {
-            set_baton_error(error, status, "Failed to set iRODS path '%s'",
-                            root_path);
-            goto error;
-        }
+        set_rods_path(conn, &rods_path, root_path, error);
+        if (error->code != 0) goto error;
 
         if (str_starts_with(root_path, "/", MAX_STR_LEN)) {
             // Is search path just a zone hint? e.g. "/seq"
@@ -722,7 +718,6 @@ json_t *add_checksum_json_object(rcComm_t *conn, json_t *object,
     char *path = NULL;
     rodsPath_t rods_path;
     json_t *checksum;
-    int status;
 
     init_baton_error(error);
 
@@ -735,11 +730,8 @@ json_t *add_checksum_json_object(rcComm_t *conn, json_t *object,
     path = json_to_path(object, error);
     if (error->code != 0) goto error;
 
-    status = set_rods_path(conn, &rods_path, path);
-    if (status < 0) {
-        set_baton_error(error, status, "Failed to set iRODS path '%s'", path);
-        goto error;
-    }
+    set_rods_path(conn, &rods_path, path, error);
+    if (error->code != 0) goto error;
 
     checksum = list_checksum(conn, &rods_path, error);
     if (error->code != 0) goto error;
@@ -787,7 +779,6 @@ json_t *add_repl_json_object(rcComm_t *conn, json_t *object,
     char *path = NULL;
     rodsPath_t rods_path;
     json_t *replicates;
-    int status;
 
     init_baton_error(error);
 
@@ -800,11 +791,8 @@ json_t *add_repl_json_object(rcComm_t *conn, json_t *object,
     path = json_to_path(object, error);
     if (error->code != 0) goto error;
 
-    status = set_rods_path(conn, &rods_path, path);
-    if (status < 0) {
-        set_baton_error(error, status, "Failed to set iRODS path '%s'", path);
-        goto error;
-    }
+    set_rods_path(conn, &rods_path, path, error);
+    if (error->code != 0) goto error;
 
     replicates = list_replicates(conn, &rods_path, error);
     if (error->code != 0) goto error;
@@ -867,11 +855,8 @@ json_t *add_tps_json_object(rcComm_t *conn, json_t *object,
     path = json_to_path(object, error);
     if (error->code != 0) goto error;
 
-    int status = set_rods_path(conn, &rods_path, path);
-    if (status < 0) {
-        set_baton_error(error, status, "Failed to set iRODS path '%s'", path);
-        goto error;
-    }
+    set_rods_path(conn, &rods_path, path, error);
+    if (error->code != 0) goto error;
 
     raw_timestamps = list_timestamps(conn, &rods_path, error);
     if (error->code != 0) goto error;
@@ -963,7 +948,6 @@ json_t *add_avus_json_object(rcComm_t *conn, json_t *object,
     char *path = NULL;
     rodsPath_t rods_path;
     json_t *avus;
-    int status;
 
     init_baton_error(error);
 
@@ -976,11 +960,8 @@ json_t *add_avus_json_object(rcComm_t *conn, json_t *object,
     path = json_to_path(object, error);
     if (error->code != 0) goto error;
 
-    status = set_rods_path(conn, &rods_path, path);
-    if (status < 0) {
-        set_baton_error(error, status, "Failed to set iRODS path '%s'", path);
-        goto error;
-    }
+    set_rods_path(conn, &rods_path, path, error);
+    if (error->code != 0) goto error;
 
     avus = list_metadata(conn, &rods_path, NULL, error);
     if (error->code != 0) goto error;
@@ -1028,7 +1009,6 @@ json_t *add_acl_json_object(rcComm_t *conn, json_t *object,
     char *path = NULL;
     rodsPath_t rods_path;
     json_t *perms;
-    int status;
 
     init_baton_error(error);
 
@@ -1041,11 +1021,8 @@ json_t *add_acl_json_object(rcComm_t *conn, json_t *object,
     path = json_to_path(object, error);
     if (error->code != 0) goto error;
 
-    status = set_rods_path(conn, &rods_path, path);
-    if (status < 0) {
-        set_baton_error(error, status, "Failed to set iRODS path '%s'", path);
-        goto error;
-    }
+    set_rods_path(conn, &rods_path, path, error);
+    if (error->code != 0) goto error;
 
     perms = list_permissions(conn, &rods_path, error);
     if (error->code != 0) goto error;


### PR DESCRIPTION
Bug fix: avoid trimming a trailing slash from the root collection.

Bug fix: the correct code may not returned when getting iRODS
object types (in the case of errors).

Added an error parameter to set_irod_path to allow removal removal
of duplicate code.