### PR TITLE
Enhanced baton-do

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -134,7 +134,7 @@ stream of JSON objects on standard output. The ``baton`` programs are:
 * `baton-do`_
 
   Perform a mixture of list, chmod, get, put, metamod or metaquery
-  ``baton`` operations specified by parameters supplied as JSON.
+  ``baton`` operations specified by arguments supplied as JSON.
 
 All of the programs are designed to accept a stream of JSON objects,
 one for each operation on a collection or data object. After each
@@ -661,7 +661,7 @@ Synopsis:
 .. code-block:: sh
 
    $ jq -n '{"operation": "metaquery",
-             "parameters": {
+             "arguments": {
                  "avu": true,
                  "acl": true,
                  "replicate": true,
@@ -676,13 +676,13 @@ to be carried out, along with any parameters for that operation.
 
 The JSON envelope has two mandatory properties; `operation`, whose
 value must be a string naming a ``baton`` operation to be performed
-(one of `chmod`, `get`, `put`, `list`, `metamod`, `metaquery`) and
-`target` which must be a ``baton``-format JSON object. The envelope
-has one optional property `parameters` which, if present, must be a
-JSON object whose keys and values may be any of the command line
-options permitted for the standard ``baton`` clients supporting the
-previously named operations. Where command line options are boolean
-flags, a JSON `true` value should be used.
+(one of `checksum`, `chmod`, `get`, `put`, `list`, `metamod`,
+`metaquery`, `move`) and `target` which must be a ``baton``-format
+JSON object. The envelope has one optional property `arguments` which,
+if present, must be a JSON object whose keys and values may be any of
+the command line options permitted for the standard ``baton`` clients
+supporting the previously named operations. Where command line options
+are boolean flags, a JSON `true` value should be used.
 
 Options
 ^^^^^^^

--- a/src/baton-chmod.c
+++ b/src/baton-chmod.c
@@ -113,7 +113,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (unsafe_flag)     flags = flags | UNSAFE_RESOLVE;
-    if (recurse_flag)    flags = flags | RECURSE;
+    if (recurse_flag)    flags = flags | RECURSIVE;
     if (unbuffered_flag) flags = flags | FLUSH;
 
     if (debug_flag)   set_log_threshold(DEBUG);

--- a/src/baton-chmod.c
+++ b/src/baton-chmod.c
@@ -123,7 +123,9 @@ int main(int argc, char *argv[]) {
     declare_client_name(argv[0]);
     input = maybe_stdin(json_file);
 
-    int status = do_operation(input, baton_json_chmod_op, flags);
+    operation_args_t args = { .flags = flags };
+
+    int status = do_operation(input, baton_json_chmod_op, &args);
     if (input != stdin) fclose(input);
 
     if (status != 0) exit_status = 5;

--- a/src/baton-do.c
+++ b/src/baton-do.c
@@ -121,8 +121,11 @@ int main(int argc, char *argv[]) {
     declare_client_name(argv[0]);
     input = maybe_stdin(json_file);
 
-    int status = do_operation(input, baton_json_dispatch_op, flags, zone_name,
-                              default_buffer_size);
+    operation_args_t args = { .flags       = flags,
+                              .buffer_size = default_buffer_size,
+                              .zone_name   = zone_name };
+
+    int status = do_operation(input, baton_json_dispatch_op, &args);
     if (input != stdin) fclose(input);
 
     if (status != 0) exit_status = 5;

--- a/src/baton-do.c
+++ b/src/baton-do.c
@@ -28,6 +28,7 @@ static int debug_flag      = 0;
 static int help_flag       = 0;
 static int silent_flag     = 0;
 static int unbuffered_flag = 0;
+static int unsafe_flag     = 0;
 static int verbose_flag    = 0;
 static int version_flag    = 0;
 
@@ -47,6 +48,7 @@ int main(int argc, char *argv[]) {
             {"help",        no_argument, &help_flag,       1},
             {"silent",      no_argument, &silent_flag,     1},
             {"unbuffered",  no_argument, &unbuffered_flag, 1},
+            {"unsafe",      no_argument, &unsafe_flag,     1},
             {"verbose",     no_argument, &verbose_flag,    1},
             {"version",     no_argument, &version_flag,    1},
             // Indexed options
@@ -98,6 +100,7 @@ int main(int argc, char *argv[]) {
         "                  Optional, defaults to STDIN.\n"
         "    --silent      Silence error messages.\n"
         "    --unbuffered  Flush print operations for each JSON object.\n"
+
         "    --verbose     Print verbose messages to STDERR.\n"
         "    --version     Print the version number and exit.\n"
         "    --zone        The zone to operate within. Optional.\n";
@@ -113,6 +116,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (unbuffered_flag) flags = flags | FLUSH;
+    if (unsafe_flag)     flags = flags | UNSAFE_RESOLVE;
 
     if (debug_flag)   set_log_threshold(DEBUG);
     if (verbose_flag) set_log_threshold(NOTICE);

--- a/src/baton-get.c
+++ b/src/baton-get.c
@@ -187,8 +187,10 @@ int main(int argc, char *argv[]) {
 
     logmsg(DEBUG, "Using a transfer buffer size of %zu bytes", buffer_size);
 
-    int status = do_operation(input, baton_json_get_op, flags, NULL,
-                              buffer_size);
+    operation_args_t args = { .flags       = flags,
+                              .buffer_size = buffer_size };
+
+    int status = do_operation(input, baton_json_get_op, &args);
     if (input != stdin) fclose(input);
 
     if (status != 0) exit_status = 5;

--- a/src/baton-list.c
+++ b/src/baton-list.c
@@ -150,7 +150,9 @@ int main(int argc, char *argv[]) {
     declare_client_name(argv[0]);
     input = maybe_stdin(json_file);
 
-    int status = do_operation(input, baton_json_list_op, flags);
+    operation_args_t args = { .flags = flags };
+
+    int status = do_operation(input, baton_json_list_op, &args);
     if (input != stdin) fclose(input);
 
     if (status != 0) exit_status = 5;

--- a/src/baton-metamod.c
+++ b/src/baton-metamod.c
@@ -135,7 +135,9 @@ int main(int argc, char *argv[]) {
     declare_client_name(argv[0]);
     input = maybe_stdin(json_file);
 
-    int status = do_operation(input, baton_json_metamod_op, flags);
+    operation_args_t args = { .flags = flags };
+
+    int status = do_operation(input, baton_json_metamod_op, &args);
     if (input != stdin) fclose(input);
 
     if (status != 0) exit_status = 5;

--- a/src/baton-metaquery.c
+++ b/src/baton-metaquery.c
@@ -165,8 +165,10 @@ int main(int argc, char *argv[]) {
     declare_client_name(argv[0]);
     input = maybe_stdin(json_file);
 
-    int status = do_operation(input, baton_json_metaquery_op, flags,
-                              zone_name);
+    operation_args_t args = { .flags     = flags,
+                              .zone_name = zone_name };
+
+    int status = do_operation(input, baton_json_metaquery_op, &args);
     if (input != stdin) fclose(input);
 
     if (status != 0) exit_status = 5;

--- a/src/baton-put.c
+++ b/src/baton-put.c
@@ -156,8 +156,11 @@ int main(int argc, char *argv[]) {
 
     logmsg(DEBUG, "Using a transfer buffer size of %zu bytes", buffer_size);
 
-    int status = do_operation(input, baton_json_put_op, flags, zone_name,
-                              buffer_size);
+    operation_args_t args = { .flags       = flags,
+                              .buffer_size = default_buffer_size,
+                              .zone_name   = zone_name };
+
+    int status = do_operation(input, baton_json_put_op, &args);
     if (input != stdin) fclose(input);
 
     if (status != 0)    exit_status = 5;

--- a/src/baton.c
+++ b/src/baton.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2016 Genome Research Ltd. All
+ * Copyright (C) 2013, 2014, 2015, 2016, 2017 Genome Research Ltd. All
  * rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/baton.h
+++ b/src/baton.h
@@ -58,6 +58,11 @@ typedef struct mod_metadata_in {
     char *attr_units;
 } mod_metadata_in_t;
 
+typedef struct baton_session {
+    rodsEnv *env;
+    rcComm_t *connection;
+} baton_session_t;
+
 /**
  * Test that a connection can be made to the server.
  *
@@ -125,6 +130,9 @@ int resolve_rods_path(rcComm_t *conn, rodsEnv *env,
  */
 int set_rods_path(rcComm_t *conn, rodsPath_t *rods_path, char *path,
                   baton_error_t *error);
+
+int move_rods_path(rcComm_t *conn, rodsPath_t *rods_path, char *new_path,
+                   baton_error_t *error);
 
 int resolve_collection(json_t *object, rcComm_t *conn, rodsEnv *env,
                        option_flags flags, baton_error_t *error);

--- a/src/json.c
+++ b/src/json.c
@@ -527,7 +527,7 @@ const char *get_timestamp_operator(json_t *timestamp, baton_error_t *error) {
                                 JSON_OPERATOR_SHORT_KEY, error);
 }
 
-const char *get_operation_name(json_t *envelope, baton_error_t *error) {
+const char *get_operation_arg(json_t *envelope, baton_error_t *error) {
     init_baton_error(error);
 
     return get_string_value(envelope, "operation name", JSON_OPERATION_KEY,
@@ -570,6 +570,13 @@ json_t *get_operation_params(json_t *envelope, baton_error_t *error) {
 
 error:
     return NULL;
+}
+
+const char *get_operation_name(json_t *parameters, baton_error_t *error) {
+    init_baton_error(error);
+
+    return get_opt_string_value(parameters, "operation", JSON_OPERATION_KEY,
+                                JSON_OPERATION_SHORT_KEY, error);
 }
 
 int has_collection(json_t *object) {
@@ -647,9 +654,14 @@ int contents_p(json_t *operation_params) {
 int object_p(json_t *operation_params) {
     return json_is_true(json_object_get(operation_params, JSON_PARAM_OBJECT));
 }
+
 int operation_p(json_t *operation_params) {
     return json_is_true(json_object_get(operation_params,
                                         JSON_PARAM_OPERATION));
+}
+
+int operation_argument_p(json_t *operation_params) {
+    return json_object_get(operation_params, JSON_PARAM_OPERATION) != NULL;
 }
 
 int raw_p(json_t *operation_params) {

--- a/src/json.c
+++ b/src/json.c
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015 Genome Research Ltd. All rights
- * reserved.
+ * Copyright (C) 2013, 2014, 2015, 2017 Genome Research Ltd. All
+ * rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -527,24 +527,24 @@ const char *get_timestamp_operator(json_t *timestamp, baton_error_t *error) {
                                 JSON_OPERATOR_SHORT_KEY, error);
 }
 
-const char *get_operation_name(json_t *envelope, baton_error_t *error) {
+const char *get_operation(json_t *envelope, baton_error_t *error) {
     init_baton_error(error);
 
-    return get_opt_string_value(envelope, "operation", JSON_OPERATION_KEY,
-                                JSON_OPERATION_SHORT_KEY, error);
+    return get_opt_string_value(envelope, "operation", JSON_OP_KEY,
+                                JSON_OP_SHORT_KEY, error);
 }
 
-json_t *get_operation_params(json_t *envelope, baton_error_t *error) {
+json_t *get_operation_args(json_t *envelope, baton_error_t *error) {
     init_baton_error(error);
 
-    json_t *params = get_json_value(envelope, "operation parameters",
-                                    JSON_PARAMS_KEY, JSON_PARAMS_SHORT_KEY,
+    json_t *params = get_json_value(envelope, "operation arguments",
+                                    JSON_OP_ARGS_KEY, JSON_OP_ARGS_SHORT_KEY,
                                     error);
     if (error->code != 0) goto error;
     if (!json_is_object(params)) {
         set_baton_error(error, CAT_INVALID_ARGUMENT,
                         "Invalid '%s' attribute: not a JSON object",
-                        JSON_PARAMS_KEY);
+                        JSON_OP_ARGS_KEY);
         goto error;
     }
 
@@ -573,21 +573,95 @@ error:
     return NULL;
 }
 
-const char *get_operation_arg(json_t *operation_params,
-                              baton_error_t *error) {
-    init_baton_error(error);
-
-    return get_string_value(operation_params, "operation arg",
-                            JSON_OPERATION_KEY,
-                            JSON_OPERATION_SHORT_KEY, error);
+int has_operation(json_t *object) {
+    return has_json_str_value(object, JSON_OP_KEY, JSON_OP_SHORT_KEY);
 }
 
-const char *get_operation_path(json_t *operation_params,
-                               baton_error_t *error) {
+int has_operation_args(json_t *object) {
+    baton_error_t error;
+
+    init_baton_error(&error); // Ignore error
+
+    return get_json_value(object, "operation arguments", JSON_OP_ARGS_KEY,
+                          JSON_OP_ARGS_SHORT_KEY, &error) != NULL;
+}
+
+int has_operation_target(json_t *envelope) {
+    return json_object_get(envelope, JSON_TARGET_KEY) != NULL;
+}
+
+int has_op_path(json_t *operation_args) {
+    return json_object_get(operation_args, JSON_OP_PATH) != NULL;
+}
+
+int op_acl_p(json_t *operation_args) {
+    return json_is_true(json_object_get(operation_args, JSON_OP_ACL));
+}
+
+int op_avu_p(json_t *operation_args) {
+    return json_is_true(json_object_get(operation_args, JSON_OP_AVU));
+}
+
+int op_checksum_p(json_t *operation_args) {
+    return json_is_true(json_object_get(operation_args, JSON_OP_CHECKSUM));
+}
+
+int op_force_p(json_t *operation_args) {
+    return json_is_true(json_object_get(operation_args, JSON_OP_FORCE));
+}
+
+int op_collection_p(json_t *operation_args) {
+    return json_is_true(json_object_get(operation_args, JSON_OP_COLLECTION));
+}
+
+int op_contents_p(json_t *operation_args) {
+    return json_is_true(json_object_get(operation_args, JSON_OP_CONTENTS));
+}
+
+int op_object_p(json_t *operation_args) {
+    return json_is_true(json_object_get(operation_args, JSON_OP_OBJECT));
+}
+
+int op_operation_p(json_t *operation_args) {
+    return json_is_true(json_object_get(operation_args, JSON_OP_OPERATION));
+}
+
+int op_raw_p(json_t *operation_args) {
+    return json_is_true(json_object_get(operation_args, JSON_OP_RAW));
+}
+
+int op_recurse_p(json_t *operation_args) {
+    return json_is_true(json_object_get(operation_args, JSON_OP_RECURSE));
+}
+
+int op_replicate_p(json_t *operation_args) {
+    return json_is_true(json_object_get(operation_args, JSON_OP_REPLICATE));
+}
+
+int op_save_p(json_t *operation_args) {
+    return json_is_true(json_object_get(operation_args, JSON_OP_SAVE));
+}
+
+int op_size_p(json_t *operation_args) {
+    return json_is_true(json_object_get(operation_args, JSON_OP_SIZE));
+}
+
+int op_timestamp_p(json_t *operation_args) {
+    return json_is_true(json_object_get(operation_args, JSON_OP_TIMESTAMP));
+}
+
+const char *get_op(json_t *operation_args, baton_error_t *error) {
     init_baton_error(error);
 
-    return get_string_value(operation_params, "operation path",
-                            JSON_PARAM_PATH, NULL, error);
+    return get_string_value(operation_args, "operation op", JSON_OP_KEY,
+                            JSON_OP_SHORT_KEY, error);
+}
+
+const char *get_op_path(json_t *operation_args, baton_error_t *error) {
+    init_baton_error(error);
+
+    return get_string_value(operation_args, "operation path",
+                            JSON_OP_PATH, NULL, error);
 }
 
 int has_collection(json_t *object) {
@@ -619,90 +693,6 @@ int has_created_timestamp(json_t *object) {
 int has_modified_timestamp(json_t *object) {
     return has_json_str_value(object, JSON_MODIFIED_KEY,
                               JSON_MODIFIED_SHORT_KEY);
-}
-
-int has_operation(json_t *object) {
-  return has_json_str_value(object, JSON_OPERATION_KEY,
-                            JSON_OPERATION_SHORT_KEY);
-}
-
-int has_operation_params(json_t *object) {
-    baton_error_t error;
-
-    init_baton_error(&error); // Ignore error
-
-    return get_json_value(object, "operation params", JSON_PARAMS_KEY,
-                          JSON_PARAMS_SHORT_KEY, &error) != NULL;
-}
-
-int has_operation_target(json_t *object) {
-    return json_object_get(object, JSON_TARGET_KEY) != NULL;
-}
-
-int has_operation_arg(json_t *operation_params) {
-    return json_object_get(operation_params, JSON_PARAM_OPERATION) != NULL;
-}
-
-int has_operation_path(json_t *operation_params) {
-    return json_object_get(operation_params, JSON_PARAM_PATH) != NULL;
-}
-
-int acl_p(json_t *operation_params) {
-    return json_is_true(json_object_get(operation_params, JSON_PARAM_ACL));
-}
-
-int avu_p(json_t *operation_params) {
-    return json_is_true(json_object_get(operation_params, JSON_PARAM_AVU));
-}
-
-int checksum_p(json_t *operation_params) {
-    return json_is_true(json_object_get(operation_params,
-                                        JSON_PARAM_CHECKSUM));
-}
-
-int collection_p(json_t *operation_params) {
-    return json_is_true(json_object_get(operation_params,
-                                        JSON_PARAM_COLLECTION));
-}
-
-int contents_p(json_t *operation_params) {
-    return json_is_true(json_object_get(operation_params,
-                                        JSON_PARAM_CONTENTS));
-}
-
-int object_p(json_t *operation_params) {
-    return json_is_true(json_object_get(operation_params, JSON_PARAM_OBJECT));
-}
-
-int operation_p(json_t *operation_params) {
-    return json_is_true(json_object_get(operation_params,
-                                        JSON_PARAM_OPERATION));
-}
-
-int raw_p(json_t *operation_params) {
-    return json_is_true(json_object_get(operation_params, JSON_PARAM_RAW));
-}
-
-int recurse_p(json_t *operation_params) {
-    return json_is_true(json_object_get(operation_params, JSON_PARAM_RECURSE));
-}
-
-int replicate_p(json_t *operation_params) {
-    return json_is_true(json_object_get(operation_params,
-                                        JSON_PARAM_REPLICATE));
-}
-
-int save_p(json_t *operation_params) {
-    return json_is_true(json_object_get(operation_params, JSON_PARAM_SAVE));
-}
-
-int size_p(json_t *operation_params) {
-    return json_is_true(json_object_get(operation_params, JSON_PARAM_SIZE));
-}
-
-int timestamp_p(json_t *operation_params) {
-    return json_is_true(json_object_get(operation_params,
-                                        JSON_PARAM_TIMESTAMP));
 }
 
 int contains_avu(json_t *avus, json_t *avu) {

--- a/src/json.h
+++ b/src/json.h
@@ -103,6 +103,7 @@
 #define JSON_METAMOD_OPERATION     "metamod"
 #define JSON_METAQUERY_OPERATION   "metaquery"
 #define JSON_PUT_OPERATION         "put"
+#define JSON_MOVE_OPERATION        "move"
 
 #define JSON_PARAMS_KEY            "parameters"
 #define JSON_PARAMS_SHORT_KEY      "params"
@@ -120,6 +121,7 @@
 #define JSON_PARAM_SAVE            "save"
 #define JSON_PARAM_SIZE            "size"
 #define JSON_PARAM_TIMESTAMP       "timestamp"
+#define JSON_PARAM_PATH            "path"
 
 #define JSON_ARG_META_ADD          "add"
 #define JSON_ARG_META_REM          "rem"
@@ -238,7 +240,9 @@ json_t *get_operation_target(json_t *envelope, baton_error_t *error);
 
 json_t *get_operation_params(json_t *envelope, baton_error_t *error);
 
-const char *get_operation_arg(json_t *envelope, baton_error_t *error);
+const char *get_operation_arg(json_t *operation_params, baton_error_t *error);
+
+const char *get_operation_path(json_t *operation_params, baton_error_t *error);
 
 int has_collection(json_t *object);
 
@@ -250,11 +254,15 @@ int has_created_timestamp(json_t *object);
 
 int has_modified_timestamp(json_t *object);
 
-int has_operation(json_t *object);
+int has_operation(json_t *envelope);
 
-int has_operation_params(json_t *object);
+int has_operation_params(json_t *envelope);
 
-int has_operation_target(json_t *object);
+int has_operation_target(json_t *envelope);
+
+int has_operation_arg(json_t *operation_params);
+
+int has_operation_path(json_t *operation_params);
 
 int acl_p(json_t *operation_params);
 
@@ -269,8 +277,6 @@ int contents_p(json_t *operation_params);
 int object_p(json_t *operation_params);
 
 int operation_p(json_t *operation_params);
-
-int operation_argument_p(json_t *operation_params);
 
 int raw_p(json_t *operation_params);
 

--- a/src/json.h
+++ b/src/json.h
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015 Genome Research Ltd. All rights
- * reserved.
+ * Copyright (C) 2013, 2014, 2015, 2017 Genome Research Ltd. All
+ * rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -85,6 +85,8 @@
 #define JSON_OPERATOR_SHORT_KEY    "o"
 #define JSON_ARGS_KEY              "args"
 #define JSON_ARGS_SHORT_KEY        "?"
+#define JSON_ARG_META_ADD          "add"
+#define JSON_ARG_META_REM          "rem"
 
 // SQL specific query operations
 #define JSON_SPECIFIC_KEY          "specific"
@@ -94,37 +96,36 @@
 // baton operations
 #define JSON_TARGET_KEY            "target"
 #define JSON_RESULT_KEY            "result"
-#define JSON_OPERATION_KEY         "operation"
-#define JSON_OPERATION_SHORT_KEY   "op"
+#define JSON_OP_KEY                "operation"
+#define JSON_OP_SHORT_KEY          "op"
 
-#define JSON_CHMOD_OPERATION       "chmod"
-#define JSON_GET_OPERATION         "get"
-#define JSON_LIST_OPERATION        "list"
-#define JSON_METAMOD_OPERATION     "metamod"
-#define JSON_METAQUERY_OPERATION   "metaquery"
-#define JSON_PUT_OPERATION         "put"
-#define JSON_MOVE_OPERATION        "move"
+#define JSON_CHMOD_OP              "chmod"
+#define JSON_CHECKSUM_OP           "checksum"
+#define JSON_GET_OP                "get"
+#define JSON_LIST_OP               "list"
+#define JSON_METAMOD_OP            "metamod"
+#define JSON_METAQUERY_OP          "metaquery"
+#define JSON_PUT_OP                "put"
+#define JSON_MOVE_OP               "move"
 
-#define JSON_PARAMS_KEY            "parameters"
-#define JSON_PARAMS_SHORT_KEY      "params"
+#define JSON_OP_ARGS_KEY           "arguments"
+#define JSON_OP_ARGS_SHORT_KEY     "args"
 
-#define JSON_PARAM_ACL             "acl"
-#define JSON_PARAM_AVU             "avu"
-#define JSON_PARAM_CHECKSUM        "checksum"
-#define JSON_PARAM_COLLECTION      "collection"
-#define JSON_PARAM_CONTENTS        "contents"
-#define JSON_PARAM_OBJECT          "object"
-#define JSON_PARAM_OPERATION       "operation"
-#define JSON_PARAM_RAW             "raw"
-#define JSON_PARAM_RECURSE         "recurse"
-#define JSON_PARAM_REPLICATE       "replicate"
-#define JSON_PARAM_SAVE            "save"
-#define JSON_PARAM_SIZE            "size"
-#define JSON_PARAM_TIMESTAMP       "timestamp"
-#define JSON_PARAM_PATH            "path"
-
-#define JSON_ARG_META_ADD          "add"
-#define JSON_ARG_META_REM          "rem"
+#define JSON_OP_ACL                "acl"
+#define JSON_OP_AVU                "avu"
+#define JSON_OP_CHECKSUM           "checksum"
+#define JSON_OP_FORCE              "force"
+#define JSON_OP_COLLECTION         "collection"
+#define JSON_OP_CONTENTS           "contents"
+#define JSON_OP_OBJECT             "object"
+#define JSON_OP_OPERATION          "operation"
+#define JSON_OP_RAW                "raw"
+#define JSON_OP_RECURSE            "recurse"
+#define JSON_OP_REPLICATE          "replicate"
+#define JSON_OP_SAVE               "save"
+#define JSON_OP_SIZE               "size"
+#define JSON_OP_TIMESTAMP          "timestamp"
+#define JSON_OP_PATH               "path"
 
 #define VALID_REPLICATE   "1"
 #define INVALID_REPLICATE "0"
@@ -234,15 +235,49 @@ const char *get_access_zone(json_t *access, baton_error_t *error);
 
 const char *get_timestamp_operator(json_t *timestamp, baton_error_t *error);
 
-const char *get_operation_name(json_t *envelope, baton_error_t *error);
+const char *get_operation(json_t *object, baton_error_t *error);
+
+json_t *get_operation_args(json_t *envelope, baton_error_t *error);
 
 json_t *get_operation_target(json_t *envelope, baton_error_t *error);
 
-json_t *get_operation_params(json_t *envelope, baton_error_t *error);
+const char *get_op_path(json_t *operation_args, baton_error_t *error);
 
-const char *get_operation_arg(json_t *operation_params, baton_error_t *error);
+int has_operation(json_t *object);
 
-const char *get_operation_path(json_t *operation_params, baton_error_t *error);
+int has_operation_args(json_t *object);
+
+int has_operation_target(json_t *envelope);
+
+int has_op_path(json_t *operation_args);
+
+int op_acl_p(json_t *operation_args);
+
+int op_avu_p(json_t *operation_args);
+
+int op_checksum_p(json_t *operation_args);
+
+int op_force_p(json_t *operation_args);
+
+int op_collection_p(json_t *operation_args);
+
+int op_contents_p(json_t *operation_args);
+
+int op_object_p(json_t *operation_args);
+
+int op_operation_p(json_t *operation_args);
+
+int op_raw_p(json_t *operation_args);
+
+int op_recurse_p(json_t *operation_args);
+
+int op_replicate_p(json_t *operation_args);
+
+int op_save_p(json_t *operation_args);
+
+int op_size_p(json_t *operation_args);
+
+int op_timestamp_p(json_t *operation_args);
 
 int has_collection(json_t *object);
 
@@ -253,42 +288,6 @@ int has_timestamps(json_t *object);
 int has_created_timestamp(json_t *object);
 
 int has_modified_timestamp(json_t *object);
-
-int has_operation(json_t *envelope);
-
-int has_operation_params(json_t *envelope);
-
-int has_operation_target(json_t *envelope);
-
-int has_operation_arg(json_t *operation_params);
-
-int has_operation_path(json_t *operation_params);
-
-int acl_p(json_t *operation_params);
-
-int avu_p(json_t *operation_params);
-
-int checksum_p(json_t *operation_params);
-
-int collection_p(json_t *operation_params);
-
-int contents_p(json_t *operation_params);
-
-int object_p(json_t *operation_params);
-
-int operation_p(json_t *operation_params);
-
-int raw_p(json_t *operation_params);
-
-int recurse_p(json_t *operation_params);
-
-int replicate_p(json_t *operation_params);
-
-int save_p(json_t *operation_params);
-
-int size_p(json_t *operation_params);
-
-int timestamp_p(json_t *operation_params);
 
 int contains_avu(json_t *avus, json_t *avu);
 

--- a/src/json.h
+++ b/src/json.h
@@ -121,6 +121,9 @@
 #define JSON_PARAM_SIZE            "size"
 #define JSON_PARAM_TIMESTAMP       "timestamp"
 
+#define JSON_ARG_META_ADD          "add"
+#define JSON_ARG_META_REM          "rem"
+
 #define VALID_REPLICATE   "1"
 #define INVALID_REPLICATE "0"
 
@@ -235,6 +238,8 @@ json_t *get_operation_target(json_t *envelope, baton_error_t *error);
 
 json_t *get_operation_params(json_t *envelope, baton_error_t *error);
 
+const char *get_operation_arg(json_t *envelope, baton_error_t *error);
+
 int has_collection(json_t *object);
 
 int has_acl(json_t *object);
@@ -264,6 +269,8 @@ int contents_p(json_t *operation_params);
 int object_p(json_t *operation_params);
 
 int operation_p(json_t *operation_params);
+
+int operation_argument_p(json_t *operation_params);
 
 int raw_p(json_t *operation_params);
 

--- a/src/json_query.c
+++ b/src/json_query.c
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015 Genome Research Ltd. All rights
- * reserved.
+ * Copyright (C) 2013, 2014, 2015, 2016 Genome Research Ltd. All
+ * rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/json_query.h
+++ b/src/json_query.h
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015 Genome Research Ltd. All rights
- * reserved.
+ * Copyright (C) 2013, 2014, 2015, 2016 Genome Research Ltd. All
+ * rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/list.c
+++ b/src/list.c
@@ -20,6 +20,7 @@
  */
 
 #include "list.h"
+#include "read.h"
 
 static json_t *list_data_object(rcComm_t *conn, rodsPath_t *rods_path,
                                 option_flags flags, baton_error_t *error) {
@@ -178,71 +179,7 @@ error:
 
 json_t *list_checksum(rcComm_t *conn, rodsPath_t *rods_path,
                       baton_error_t *error) {
-    char *checksum_str = NULL;
-    json_t *checksum = NULL;
-
-    dataObjInp_t obj_chk_in;
-    memset(&obj_chk_in, 0, sizeof obj_chk_in);
-    obj_chk_in.openFlags = O_RDONLY;
-
-    init_baton_error(error);
-
-    if (rods_path->objState == NOT_EXIST_ST) {
-        set_baton_error(error, USER_FILE_DOES_NOT_EXIST,
-                        "Path '%s' does not exist "
-                        "(or lacks access permission)", rods_path->outPath);
-        goto error;
-    }
-
-    switch (rods_path->objType) {
-        case DATA_OBJ_T:
-            logmsg(TRACE, "Identified '%s' as a data object",
-                   rods_path->outPath);
-            snprintf(obj_chk_in.objPath, MAX_NAME_LEN, "%s",
-                     rods_path->outPath);
-            break;
-
-        case COLL_OBJ_T:
-            logmsg(TRACE, "Identified '%s' as a collection",
-                   rods_path->outPath);
-            set_baton_error(error, USER_INPUT_PATH_ERR,
-                            "Failed to list checksum of '%s' as it is "
-                            "a collection", rods_path->outPath);
-            break;
-
-        default:
-            set_baton_error(error, USER_INPUT_PATH_ERR,
-                            "Failed to list checksum of '%s' as it is "
-                            "neither data object nor collection",
-                            rods_path->outPath);
-            goto error;
-    }
-
-    logmsg(DEBUG, "Checksumming data object '%s'", rods_path->outPath);
-
-    int status = rcDataObjChksum(conn, &obj_chk_in, &checksum_str);
-    if (status < 0) {
-        char *err_subname;
-        char *err_name = rodsErrorName(status, &err_subname);
-        set_baton_error(error, status,
-                        "Failed to list checksum of '%s': %d %s",
-                        rods_path->outPath, status, err_name);
-        goto error;
-    }
-
-    checksum = json_pack("s", checksum_str);
-    if (!checksum) {
-        set_baton_error(error, -1, "Failed to pack checksum '%s' as JSON",
-                        checksum_str);
-        goto error;
-    }
-
-    return checksum;
-
-error:
-    if (checksum) json_decref(checksum);
-
-    return NULL;
+    return checksum_data_obj(conn, rods_path, 0, error);
 }
 
 json_t *list_path(rcComm_t *conn, rodsPath_t *rods_path, option_flags flags,

--- a/src/list.h
+++ b/src/list.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2016, 2017Genome Research Ltd. All
+ * Copyright (C) 2013, 2014, 2015, 2016, 2017 Genome Research Ltd. All
  * rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/operations.c
+++ b/src/operations.c
@@ -24,8 +24,8 @@
 #include "operations.h"
 
 static int iterate_json(FILE *input, rodsEnv *env, rcComm_t *conn,
-                        baton_json_op fn, option_flags flags, int *item_count,
-                        va_list args) {
+                        baton_json_op fn, operation_args_t *args,
+                        int *item_count) {
     int error_count = 0;
 
     while (!feof(input)) {
@@ -50,11 +50,8 @@ static int iterate_json(FILE *input, rodsEnv *env, rcComm_t *conn,
             continue;
         }
 
-        va_list fnargs;
-        va_copy(fnargs, args);
-
         baton_error_t error;
-        json_t *result = fn(env, conn, item, flags, &error, fnargs);
+        json_t *result = fn(env, conn, item, args, &error);
         if (error.code != 0) {
             // On error, add an error report to the input JSON as a
             // property and print the input JSON
@@ -90,9 +87,8 @@ static int iterate_json(FILE *input, rodsEnv *env, rcComm_t *conn,
             }
         }
 
-        if (flags & FLUSH) fflush(stdout);
+        if (args->flags & FLUSH) fflush(stdout);
 
-        va_end(fnargs);
         (*item_count)++;
 
         json_decref(item);
@@ -101,7 +97,7 @@ static int iterate_json(FILE *input, rodsEnv *env, rcComm_t *conn,
     return error_count;
 }
 
-int do_operation(FILE *input, baton_json_op fn, option_flags flags, ...) {
+int do_operation(FILE *input, baton_json_op fn, operation_args_t *args) {
     int item_count  = 0;
     int error_count = 0;
 
@@ -111,11 +107,7 @@ int do_operation(FILE *input, baton_json_op fn, option_flags flags, ...) {
 
     if (!input) goto error;
 
-    va_list args;
-    va_start(args, flags);
-
-    error_count =
-        iterate_json(input, &env, conn, fn, flags, &item_count, args);
+    error_count = iterate_json(input, &env, conn, fn, args, &item_count);
     if (error_count > 0) {
         logmsg(WARN, "Processed %d items with %d errors",
                item_count, error_count);
@@ -124,8 +116,6 @@ int do_operation(FILE *input, baton_json_op fn, option_flags flags, ...) {
         logmsg(DEBUG, "Processed %d items with %d errors",
                item_count, error_count);
     }
-
-    va_end(args);
 
     rcDisconnect(conn);
 
@@ -141,9 +131,8 @@ error:
 }
 
 json_t *baton_json_dispatch_op(rodsEnv *env, rcComm_t *conn, json_t *envelope,
-                               option_flags flags, baton_error_t *error,
-                               va_list args) {
-    json_t *result = NULL;
+                               operation_args_t *args, baton_error_t *error) {
+    json_t *result  = NULL;
 
     const char *op = get_operation_name(envelope, error);
     if (error->code != 0) goto error;
@@ -151,10 +140,15 @@ json_t *baton_json_dispatch_op(rodsEnv *env, rcComm_t *conn, json_t *envelope,
     json_t *target = get_operation_target(envelope, error);
     if (error->code != 0) goto error;
 
+    operation_args_t args_copy = { .flags       = args->flags,
+                                   .buffer_size = args->buffer_size,
+                                   .zone_name   = args->zone_name };
+
     if (has_operation_params(envelope)) {
         json_t *params = get_operation_params(envelope, error);
         if (error->code != 0)  goto error;
 
+        option_flags flags = args_copy.flags;
         if (acl_p(params))        flags = flags | PRINT_ACL;
         if (avu_p(params))        flags = flags | PRINT_AVU;
         if (checksum_p(params))   flags = flags | PRINT_CHECKSUM;
@@ -163,17 +157,18 @@ json_t *baton_json_dispatch_op(rodsEnv *env, rcComm_t *conn, json_t *envelope,
         if (timestamp_p(params))  flags = flags | PRINT_TIMESTAMP;
         if (collection_p(params)) flags = flags | SEARCH_COLLECTIONS;
         if (object_p(params))     flags = flags | SEARCH_OBJECTS;
+        args_copy.flags = flags;
 
-        if (operation_argument_p(params)) {
+        if (has_operation_arg(params)) {
             const char *arg = get_operation_arg(params, error);
             if (error->code != 0) goto error;
 
             logmsg(DEBUG, "Detected operation argument '%s'", arg);
             if (str_equals(arg, JSON_ARG_META_ADD, MAX_STR_LEN)) {
-                flags = flags | ADD_AVU;
+                args_copy.flags = flags | ADD_AVU;
             }
             else if (str_equals(arg, JSON_ARG_META_REM, MAX_STR_LEN)) {
-                flags = flags | REMOVE_AVU;
+                args_copy.flags = flags | REMOVE_AVU;
             }
             else {
                 set_baton_error(error, -1,
@@ -181,58 +176,77 @@ json_t *baton_json_dispatch_op(rodsEnv *env, rcComm_t *conn, json_t *envelope,
               goto error;
             }
         }
+
+        if (has_operation_path(params)) {
+            const char *path = get_operation_path(params, error);
+            if (error->code != 0) goto error;
+
+            char *tmp = copy_str(path, MAX_STR_LEN);
+            if (!tmp) {
+                set_baton_error(error, errno, "Failed to copy string '%s'",
+                                path);
+                goto error;
+            }
+
+            args_copy.path = tmp;
+        }
     }
 
     if (str_equals(op, JSON_CHMOD_OPERATION, MAX_STR_LEN)) {
         logmsg(DEBUG, "Dispatching to operation '%s'", op);
-        result = baton_json_chmod_op(env, conn, target, flags, error, args);
+        result = baton_json_chmod_op(env, conn, target, &args_copy, error);
     }
     else if (str_equals(op, JSON_LIST_OPERATION, MAX_STR_LEN)) {
         logmsg(DEBUG, "Dispatching to operation '%s'", op);
-        result = baton_json_list_op(env, conn, target, flags, error, args);
+        result = baton_json_list_op(env, conn, target, &args_copy, error);
     }
     else if (str_equals(op, JSON_METAMOD_OPERATION, MAX_STR_LEN)) {
         logmsg(DEBUG, "Dispatching to operation '%s'", op);
-        result = baton_json_metamod_op(env, conn, target, flags, error, args);
+        result = baton_json_metamod_op(env, conn, target, &args_copy, error);
     }
     else if (str_equals(op, JSON_METAQUERY_OPERATION, MAX_STR_LEN)) {
         logmsg(DEBUG, "Dispatching to operation '%s'", op);
-        result = baton_json_metaquery_op(env, conn, target, flags, error, args);
+        result = baton_json_metaquery_op(env, conn, target, &args_copy, error);
     }
     else if (str_equals(op, JSON_GET_OPERATION, MAX_STR_LEN)) {
         logmsg(DEBUG, "Dispatching to operation '%s'", op);
-        result = baton_json_get_op(env, conn, target, flags, error, args);
+        result = baton_json_get_op(env, conn, target, &args_copy, error);
     }
     else if (str_equals(op, JSON_PUT_OPERATION, MAX_STR_LEN)) {
         logmsg(DEBUG, "Dispatching to operation '%s'", op);
-        result = baton_json_put_op(env, conn, target, flags, error, args);
+        result = baton_json_put_op(env, conn, target, &args_copy, error);
+    }
+    else if (str_equals(op, JSON_MOVE_OPERATION, MAX_STR_LEN)) {
+        logmsg(DEBUG, "Dispatching to operation '%s'", op);
+        result = baton_json_move_op(env, conn, target, &args_copy, error);
     }
     else {
         set_baton_error(error, -1, "Invalid baton operation '%s'", op);
         goto error;
     }
 
+    if (args_copy.path) free(args_copy.path);
+
     return result;
 
 error:
+    if (args_copy.path) free(args_copy.path);
+
     return result;
 }
 
 json_t *baton_json_list_op(rodsEnv *env, rcComm_t *conn, json_t *target,
-                           option_flags flags, baton_error_t *error,
-                           va_list args) {
-    (void) args; // Not used
-
+                           operation_args_t *args, baton_error_t *error) {
     json_t *result = NULL;
 
     char *path = json_to_path(target, error);
     if (error->code != 0) goto error;
 
     rodsPath_t rods_path;
-    resolve_rods_path(conn, env, &rods_path, path, flags, error);
+    resolve_rods_path(conn, env, &rods_path, path, args->flags, error);
     if (error->code != 0) goto error;
 
-    result = list_path(conn, &rods_path, flags, error);
+    result = list_path(conn, &rods_path, args->flags, error);
     if (error->code != 0) goto error;
 
     if (rods_path.rodsObjStat) free(rods_path.rodsObjStat);
@@ -247,10 +261,7 @@ error:
 }
 
 json_t *baton_json_chmod_op(rodsEnv *env, rcComm_t *conn, json_t *target,
-                            option_flags flags, baton_error_t *error,
-                            va_list args) {
-    (void) args; // Not used
-
+                            operation_args_t *args, baton_error_t *error) {
     json_t *result = NULL;
 
     char *path = json_to_path(target, error);
@@ -264,10 +275,10 @@ json_t *baton_json_chmod_op(rodsEnv *env, rcComm_t *conn, json_t *target,
     }
 
     rodsPath_t rods_path;
-    resolve_rods_path(conn, env, &rods_path, path, flags, error);
+    resolve_rods_path(conn, env, &rods_path, path, args->flags, error);
     if (error->code != 0) goto error;
 
-    recursive_op recurse = (flags & RECURSIVE) ? RECURSE : NO_RECURSE;
+    recursive_op recurse = (args->flags & RECURSIVE) ? RECURSE : NO_RECURSE;
 
     for (size_t i = 0; i < json_array_size(perms); i++) {
         json_t *perm = json_array_get(perms, i);
@@ -288,19 +299,18 @@ error:
 }
 
 json_t *baton_json_metaquery_op(rodsEnv *env, rcComm_t *conn, json_t *target,
-                                option_flags flags, baton_error_t *error,
-                                va_list args) {
+                                operation_args_t *args, baton_error_t *error) {
     json_t *result = NULL;
 
     if (has_collection(target)) {
-        resolve_collection(target, conn, env, flags, error);
+        resolve_collection(target, conn, env, args->flags, error);
         if (error->code != 0) goto error;
     }
 
-    char *zone_name = va_arg(args, char *);
+    char *zone_name = args->zone_name;
     logmsg(DEBUG, "Metadata query in zone '%s'", zone_name);
 
-    result = search_metadata(conn, target, zone_name, flags, error);
+    result = search_metadata(conn, target, zone_name, args->flags, error);
     if (error->code != 0) goto error;
 
     return result;
@@ -310,10 +320,7 @@ error:
 }
 
 json_t *baton_json_metamod_op(rodsEnv *env, rcComm_t *conn, json_t *target,
-                              option_flags flags, baton_error_t *error,
-                              va_list args) {
-    (void) args; // Not used
-
+                              operation_args_t *args, baton_error_t *error) {
     json_t *result = NULL;
 
     char *path = json_to_path(target, error);
@@ -327,14 +334,14 @@ json_t *baton_json_metamod_op(rodsEnv *env, rcComm_t *conn, json_t *target,
     }
 
     rodsPath_t rods_path;
-    resolve_rods_path(conn, env, &rods_path, path, flags, error);
+    resolve_rods_path(conn, env, &rods_path, path, args->flags, error);
     if (error->code != 0) goto error;
 
     metadata_op operation;
-    if (flags & ADD_AVU) {
+    if (args->flags & ADD_AVU) {
         operation = META_ADD;
     }
-    else if (flags & REMOVE_AVU) {
+    else if (args->flags & REMOVE_AVU) {
         operation = META_REM;
     }
     else {
@@ -361,37 +368,34 @@ error:
 }
 
 json_t *baton_json_get_op(rodsEnv *env, rcComm_t *conn, json_t *target,
-                          option_flags flags, baton_error_t *error,
-                          va_list args) {
+                          operation_args_t *args, baton_error_t *error) {
     json_t *result = NULL;
 
     char *path = json_to_path(target, error);
     if (error->code != 0) goto error;
 
     rodsPath_t rods_path;
-    resolve_rods_path(conn, env, &rods_path, path, flags, error);
+    resolve_rods_path(conn, env, &rods_path, path, args->flags, error);
     if (error->code != 0) goto error;
 
-    va_arg(args, char *); // zone_name not used
-    size_t buffer_size = va_arg(args, size_t);
+    size_t bsize = args->buffer_size;
+    logmsg(DEBUG, "Using a 'get' buffer size of %zu bytes", bsize);
 
-    logmsg(DEBUG, "Using a 'get' buffer size of %zu bytes", buffer_size);
-
-    if (flags & SAVE_FILES) {
+    if (args->flags & SAVE_FILES) {
         char *file = NULL;
         file = json_to_local_path(target, error);
         if (error->code != 0) goto error;
 
-        get_data_obj_file(conn, &rods_path, file, buffer_size, error);
+        get_data_obj_file(conn, &rods_path, file, bsize, error);
         free(file);
         if (error->code != 0) goto error;
     }
-    else if (flags & PRINT_RAW) {
-        get_data_obj_stream(conn, &rods_path, stdout, buffer_size, error);
+    else if (args->flags & PRINT_RAW) {
+        get_data_obj_stream(conn, &rods_path, stdout, bsize, error);
         if (error->code != 0) goto error;
     }
     else {
-        result = ingest_data_obj(conn, &rods_path, flags, buffer_size, error);
+        result = ingest_data_obj(conn, &rods_path, args->flags, bsize, error);
         if (error->code != 0) goto error;
     }
 
@@ -407,24 +411,21 @@ error:
 }
 
 json_t *baton_json_write_op(rodsEnv *env, rcComm_t *conn, json_t *target,
-                            option_flags flags, baton_error_t *error,
-                            va_list args) {
+                            operation_args_t *args, baton_error_t *error) {
     json_t *result = NULL;
 
     char *path = json_to_path(target, error);
     if (error->code != 0) goto error;
 
     rodsPath_t rods_path;
-    resolve_rods_path(conn, env, &rods_path, path, flags, error);
+    resolve_rods_path(conn, env, &rods_path, path, args->flags, error);
     if (error->code != 0) goto error;
 
     char *file = json_to_local_path(target, error);
     if (error->code != 0) goto error;
 
-    va_arg(args, char *); // zone_name not used
-    size_t buffer_size = va_arg(args, size_t);
-
-    logmsg(DEBUG, "Using a 'put' buffer size of %zu bytes", buffer_size);
+    size_t bsize = args->buffer_size;
+    logmsg(DEBUG, "Using a 'put' buffer size of %zu bytes", bsize);
 
     FILE *in = fopen(file, "r");
     if (!in) {
@@ -434,7 +435,7 @@ json_t *baton_json_write_op(rodsEnv *env, rcComm_t *conn, json_t *target,
         goto error;
     }
 
-    write_data_obj(conn, in, &rods_path, buffer_size, error);
+    write_data_obj(conn, in, &rods_path, bsize, error);
     int status = fclose(in);
 
     if (error->code != 0) goto error;
@@ -456,23 +457,20 @@ error:
 }
 
 json_t *baton_json_put_op(rodsEnv *env, rcComm_t *conn, json_t *target,
-                          option_flags flags, baton_error_t *error,
-                          va_list args) {
-    (void) args; // Not used
-
+                          operation_args_t *args, baton_error_t *error) {
     json_t *result = NULL;
 
     char *path = json_to_path(target, error);
     if (error->code != 0) goto error;
 
     rodsPath_t rods_path;
-    resolve_rods_path(conn, env, &rods_path, path, flags, error);
+    resolve_rods_path(conn, env, &rods_path, path, args->flags, error);
     if (error->code != 0) goto error;
 
     char *file = json_to_local_path(target, error);
     if (error->code != 0) goto error;
 
-    int status = put_data_obj(conn, file, &rods_path, flags, error);
+    int status = put_data_obj(conn, file, &rods_path, args->flags, error);
 
     if (error->code != 0) goto error;
     if (status != 0) {
@@ -481,6 +479,34 @@ json_t *baton_json_put_op(rodsEnv *env, rcComm_t *conn, json_t *target,
                         "README", errno, strerror(errno));
         goto error;
     }
+
+    if (path) free(path);
+
+    return result;
+
+error:
+    if (path) free(path);
+
+    return result;
+}
+
+json_t *baton_json_move_op(rodsEnv *env, rcComm_t *conn, json_t *target,
+                           operation_args_t *args, baton_error_t *error) {
+    json_t *result = NULL;
+    char *path     = NULL;
+
+    path = json_to_path(target, error);
+    if (error->code != 0) goto error;
+
+    rodsPath_t rods_path;
+    resolve_rods_path(conn, env, &rods_path, path, args->flags, error);
+    if (error->code != 0) goto error;
+
+    char *new_path = args->path;
+    logmsg(DEBUG, "Moving '%s' to '%s'", path, new_path);
+
+    move_rods_path(conn, &rods_path, new_path, error);
+    if (error->code != 0) goto error;
 
     if (path) free(path);
 

--- a/src/operations.h
+++ b/src/operations.h
@@ -85,6 +85,13 @@ typedef enum {
     CALCULATE_CHECKSUM = 1 << 17
 } option_flags;
 
+typedef struct operation_args {
+    option_flags flags;
+    size_t buffer_size;
+    char *zone_name;
+    char *path;
+} operation_args_t;
+
 /**
  * Typedef for baton JSON document processing functions.
  *
@@ -102,9 +109,8 @@ typedef enum {
 typedef json_t *(*baton_json_op) (rodsEnv *env,
                                   rcComm_t *conn,
                                   json_t *target,
-                                  option_flags flags,
-                                  baton_error_t *error,
-                                  va_list args);
+                                  operation_args_t *args,
+                                  baton_error_t *error);
 
 /**
  * Process a stream of baton JSON documents by executing the specifed
@@ -118,39 +124,43 @@ typedef json_t *(*baton_json_op) (rodsEnv *env,
  *
  * @return 0 on success, iRODS error code on failure.
  */
-int do_operation(FILE *input, baton_json_op fn, option_flags flags, ...);
+int do_operation(FILE *input, baton_json_op fn, operation_args_t *args);
 
 json_t *baton_json_dispatch_op(rodsEnv *env, rcComm_t *conn,
-                               json_t *target, option_flags flags,
-                               baton_error_t *error, va_list args);
+                               json_t *target, operation_args_t *args,
+                               baton_error_t *error);
 
 json_t *baton_json_list_op(rodsEnv *env, rcComm_t *conn,
-                           json_t *target, option_flags flags,
-                           baton_error_t *error, va_list args);
+                           json_t *target, operation_args_t *args,
+                           baton_error_t *error);
 
 json_t *baton_json_chmod_op(rodsEnv *env, rcComm_t *conn,
-                            json_t *target, option_flags flags,
-                            baton_error_t *error, va_list args);
+                            json_t *target, operation_args_t *args,
+                            baton_error_t *error);
 
 json_t *baton_json_metaquery_op(rodsEnv *env, rcComm_t *conn,
-                                json_t *target, option_flags flags,
-                                baton_error_t *error, va_list args);
+                                json_t *target, operation_args_t *args,
+                                baton_error_t *error);
 
 json_t *baton_json_metamod_op(rodsEnv *env, rcComm_t *conn,
-                              json_t *target, option_flags flags,
-                              baton_error_t *error, va_list args);
+                              json_t *target, operation_args_t *args,
+                              baton_error_t *error);
 
 json_t *baton_json_get_op(rodsEnv *env, rcComm_t *conn,
-                          json_t *target, option_flags flags,
-                          baton_error_t *error, va_list args);
+                          json_t *target, operation_args_t *args,
+                          baton_error_t *error);
 
 json_t *baton_json_put_op(rodsEnv *env, rcComm_t *conn,
-                          json_t *target, option_flags flags,
-                          baton_error_t *error, va_list args);
+                          json_t *target, operation_args_t *args,
+                          baton_error_t *error);
 
 json_t *baton_json_write_op(rodsEnv *env, rcComm_t *conn,
-                            json_t *target, option_flags flags,
-                            baton_error_t *error, va_list args);
+                            json_t *target, operation_args_t *args,
+                            baton_error_t *error);
+
+json_t *baton_json_move_op(rodsEnv *env, rcComm_t *conn,
+                           json_t *target, operation_args_t *args,
+                           baton_error_t *error);
 
 int check_str_arg(const char *arg_name, const char *arg_value,
                   size_t arg_size, baton_error_t *error);

--- a/src/operations.h
+++ b/src/operations.h
@@ -71,18 +71,20 @@ typedef enum {
     PRINT_REPLICATE    = 1 << 10,
     /** Print checksums for data objects */
     PRINT_CHECKSUM     = 1 << 11,
+    /** Calculate checksums for data objects */
+    CALCULATE_CHECKSUM = 1 << 12,
     /** Add an AVU */
-    ADD_AVU            = 1 << 12,
+    ADD_AVU            = 1 << 13,
     /** Remove an AVU */
-    REMOVE_AVU         = 1 << 13,
+    REMOVE_AVU         = 1 << 14,
     /** Recursive operation on collections */
-    RECURSIVE          = 1 << 14,
+    RECURSIVE          = 1 << 15,
     /** Save files */
-    SAVE_FILES         = 1 << 14,
+    SAVE_FILES         = 1 << 16,
     /** Flush output */
-    FLUSH              = 1 << 16,
-    /** Calculate server side checksum */
-    CALCULATE_CHECKSUM = 1 << 17
+    FLUSH              = 1 << 17,
+    /** Force an operation */
+    FORCE              = 1 << 18
 } option_flags;
 
 typedef struct operation_args {
@@ -137,6 +139,10 @@ json_t *baton_json_list_op(rodsEnv *env, rcComm_t *conn,
 json_t *baton_json_chmod_op(rodsEnv *env, rcComm_t *conn,
                             json_t *target, operation_args_t *args,
                             baton_error_t *error);
+
+json_t *baton_json_checksum_op(rodsEnv *env, rcComm_t *conn,
+                               json_t *target, operation_args_t *args,
+                               baton_error_t *error);
 
 json_t *baton_json_metaquery_op(rodsEnv *env, rcComm_t *conn,
                                 json_t *target, operation_args_t *args,

--- a/src/read.h
+++ b/src/read.h
@@ -115,6 +115,9 @@ int get_data_obj_file(rcComm_t *conn, rodsPath_t *rods_path,
 int get_data_obj_stream(rcComm_t *conn, rodsPath_t *rods_path, FILE *out,
                         size_t buffer_size, baton_error_t *error);
 
+json_t *checksum_data_obj(rcComm_t *conn, rodsPath_t *rods_path,
+                          option_flags flags, baton_error_t *error);
+
 void set_md5_last_read(data_obj_file_t *obj_file, unsigned char digest[16]);
 
 int validate_md5_last_read(rcComm_t *conn, data_obj_file_t *obj_file);

--- a/tests/check_baton.c
+++ b/tests/check_baton.c
@@ -2160,10 +2160,14 @@ START_TEST(test_do_operation) {
 
     json_dumpf(obj1, json_tmp, 0);
     json_dumpf(obj2, json_tmp, 0);
+
+    operation_args_t args = { .flags       = flags,
+                              .buffer_size = buffer_size,
+                              .zone_name   = zone_name };
+
     for (int i = 0; i < num_ops; i++) {
         rewind(json_tmp);
-        int pass_status =
-            do_operation(json_tmp, ops[i], flags, zone_name, buffer_size);
+        int pass_status = do_operation(json_tmp, ops[i], &args);
         ck_assert_int_eq(pass_status, 0);
     }
 
@@ -2171,8 +2175,7 @@ START_TEST(test_do_operation) {
     json_dumpf(incorrect_obj, json_tmp, 0);
 
     rewind(json_tmp);
-    int fail_status =
-        do_operation(json_tmp, ops[0], flags, zone_name, buffer_size);
+    int fail_status = do_operation(json_tmp, ops[0], &args);
     ck_assert_int_ne(fail_status, 0);
 
     fclose(json_tmp);


### PR DESCRIPTION
Added string parameters to baton-do for the metamod operation so that 'add' or 'rem' may be passed as arguments.

Added 'move' and 'checksum' operations.

Improved upload tests by testing the checksum of the files after a
round-trip.