### PR TITLE
Added --single-server CLI option

### DIFF
--- a/src/baton-do.c
+++ b/src/baton-do.c
@@ -24,13 +24,14 @@
 #include "config.h"
 #include "baton.h"
 
-static int debug_flag      = 0;
-static int help_flag       = 0;
-static int silent_flag     = 0;
-static int unbuffered_flag = 0;
-static int unsafe_flag     = 0;
-static int verbose_flag    = 0;
-static int version_flag    = 0;
+static int debug_flag         = 0;
+static int help_flag          = 0;
+static int silent_flag        = 0;
+static int single_server_flag = 0;
+static int unbuffered_flag    = 0;
+static int unsafe_flag        = 0;
+static int verbose_flag       = 0;
+static int version_flag       = 0;
 
 static size_t default_buffer_size = 1024 * 64 * 16 * 2;
 
@@ -44,16 +45,17 @@ int main(int argc, char *argv[]) {
     while (1) {
         static struct option long_options[] = {
             // Flag options
-            {"debug",       no_argument, &debug_flag,      1},
-            {"help",        no_argument, &help_flag,       1},
-            {"silent",      no_argument, &silent_flag,     1},
-            {"unbuffered",  no_argument, &unbuffered_flag, 1},
-            {"unsafe",      no_argument, &unsafe_flag,     1},
-            {"verbose",     no_argument, &verbose_flag,    1},
-            {"version",     no_argument, &version_flag,    1},
+            {"debug",         no_argument, &debug_flag,         1},
+            {"help",          no_argument, &help_flag,          1},
+            {"silent",        no_argument, &silent_flag,        1},
+            {"single-server", no_argument, &single_server_flag, 1},
+            {"unbuffered",    no_argument, &unbuffered_flag,    1},
+            {"unsafe",        no_argument, &unsafe_flag,        1},
+            {"verbose",       no_argument, &verbose_flag,       1},
+            {"version",       no_argument, &version_flag,       1},
             // Indexed options
-            {"file",        required_argument, NULL, 'f'},
-            {"zone",        required_argument, NULL, 'z'},
+            {"file",          required_argument, NULL, 'f'},
+            {"zone",          required_argument, NULL, 'z'},
             {0, 0, 0, 0}
         };
 
@@ -96,14 +98,15 @@ int main(int argc, char *argv[]) {
         "    Performs remote operations as described in the JSON\n"
         "    input file.\n"
         ""
-        "    --file        The JSON file describing the operations.\n"
-        "                  Optional, defaults to STDIN.\n"
-        "    --silent      Silence error messages.\n"
-        "    --unbuffered  Flush print operations for each JSON object.\n"
+        "    --file          The JSON file describing the operations.\n"
+        "                    Optional, defaults to STDIN.\n"
+        "    --silent        Silence error messages.\n"
+        "    --single-server Only connect to a single iRODS server\n"
+        "    --unbuffered    Flush print operations for each JSON object.\n"
 
-        "    --verbose     Print verbose messages to STDERR.\n"
-        "    --version     Print the version number and exit.\n"
-        "    --zone        The zone to operate within. Optional.\n";
+        "    --verbose       Print verbose messages to STDERR.\n"
+        "    --version       Print the version number and exit.\n"
+        "    --zone          The zone to operate within. Optional.\n";
 
     if (help_flag) {
         printf("%s\n",help);
@@ -115,8 +118,9 @@ int main(int argc, char *argv[]) {
         exit(0);
     }
 
-    if (unbuffered_flag) flags = flags | FLUSH;
-    if (unsafe_flag)     flags = flags | UNSAFE_RESOLVE;
+    if (single_server_flag) flags = flags | SINGLE_SERVER;
+    if (unbuffered_flag)    flags = flags | FLUSH;
+    if (unsafe_flag)        flags = flags | UNSAFE_RESOLVE;
 
     if (debug_flag)   set_log_threshold(DEBUG);
     if (verbose_flag) set_log_threshold(NOTICE);

--- a/src/json.c
+++ b/src/json.c
@@ -642,6 +642,10 @@ int op_save_p(json_t *operation_args) {
     return json_is_true(json_object_get(operation_args, JSON_OP_SAVE));
 }
 
+int op_single_server_p(json_t *operation_args) {
+  return json_is_true(json_object_get(operation_args, JSON_OP_SINGLE_SERVER));
+}
+
 int op_size_p(json_t *operation_args) {
     return json_is_true(json_object_get(operation_args, JSON_OP_SIZE));
 }

--- a/src/json.h
+++ b/src/json.h
@@ -123,6 +123,7 @@
 #define JSON_OP_RECURSE            "recurse"
 #define JSON_OP_REPLICATE          "replicate"
 #define JSON_OP_SAVE               "save"
+#define JSON_OP_SINGLE_SERVER      "single-server"
 #define JSON_OP_SIZE               "size"
 #define JSON_OP_TIMESTAMP          "timestamp"
 #define JSON_OP_PATH               "path"
@@ -274,6 +275,8 @@ int op_recurse_p(json_t *operation_args);
 int op_replicate_p(json_t *operation_args);
 
 int op_save_p(json_t *operation_args);
+
+int op_single_server_p(json_t *operation_args);
 
 int op_size_p(json_t *operation_args);
 

--- a/src/operations.h
+++ b/src/operations.h
@@ -84,7 +84,9 @@ typedef enum {
     /** Flush output */
     FLUSH              = 1 << 17,
     /** Force an operation */
-    FORCE              = 1 << 18
+    FORCE              = 1 << 18,
+    /** Avoid any operations that contact servers other than rodshost */
+    SINGLE_SERVER      = 1 << 19
 } option_flags;
 
 typedef struct operation_args {


### PR DESCRIPTION
Added --single-server CLI option to allow the user to prevent direct access to resource servers when uploading files.

Fixed some error messages that had an incorrect number of arguments to sprintf.

Avoided some redundant buffer size setting when using the put operation.