### PR TITLE
Put operation wlock support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ env:
     - PGVERSION="9.3"
     - JANSSON_VERSION="2.9"
     - CK_DEFAULT_TIMEOUT=20
-    - DISPOSABLE_IRODS_VERSION="1.2"
-    - RENCI_URL=ftp://ftp.renci.org
+    - DISPOSABLE_IRODS_VERSION="1.3"
     - WTSI_NPG_GITHUB_URL=https://github.com/wtsi-npg
   matrix:
     - IRODS_VERSION=3.3.1 IRODS_RIP_DIR=/usr/local/irods

--- a/src/baton-do.c
+++ b/src/baton-do.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2017 Genome Research Ltd. All rights reserved.
+ * Copyright (C) 2017, 2018 Genome Research Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,6 +32,7 @@ static int unbuffered_flag    = 0;
 static int unsafe_flag        = 0;
 static int verbose_flag       = 0;
 static int version_flag       = 0;
+static int wlock_flag         = 0;
 
 static size_t default_buffer_size = 1024 * 64 * 16 * 2;
 
@@ -53,6 +54,7 @@ int main(int argc, char *argv[]) {
             {"unsafe",        no_argument, &unsafe_flag,        1},
             {"verbose",       no_argument, &verbose_flag,       1},
             {"version",       no_argument, &version_flag,       1},
+            {"wlock",         no_argument, &wlock_flag,         1},
             // Indexed options
             {"file",          required_argument, NULL, 'f'},
             {"zone",          required_argument, NULL, 'z'},
@@ -92,7 +94,8 @@ int main(int argc, char *argv[]) {
         "Synopsis\n"
         "\n"
         "    baton-do [--file <JSON file>] [--silent]\n"
-        "             [--unbuffered] [--verbose] [--version]\n"
+        "             [--unbuffered] [--verbose] [--version] [--wlock]\n"
+        "             [--zone]\n"
         "\n"
         "Description\n"
         "    Performs remote operations as described in the JSON\n"
@@ -106,6 +109,8 @@ int main(int argc, char *argv[]) {
 
         "    --verbose       Print verbose messages to STDERR.\n"
         "    --version       Print the version number and exit.\n"
+        "    --wlock         Enable server-side advisory write locking.\n"
+        "                    Optional, defaults to false.\n"
         "    --zone          The zone to operate within. Optional.\n";
 
     if (help_flag) {
@@ -121,6 +126,7 @@ int main(int argc, char *argv[]) {
     if (single_server_flag) flags = flags | SINGLE_SERVER;
     if (unbuffered_flag)    flags = flags | FLUSH;
     if (unsafe_flag)        flags = flags | UNSAFE_RESOLVE;
+    if (wlock_flag)         flags = flags | WRITE_LOCK;
 
     if (debug_flag)   set_log_threshold(DEBUG);
     if (verbose_flag) set_log_threshold(NOTICE);

--- a/src/baton-put.c
+++ b/src/baton-put.c
@@ -33,6 +33,7 @@ static int unbuffered_flag    = 0;
 static int unsafe_flag        = 0;
 static int verbose_flag       = 0;
 static int version_flag       = 0;
+static int wlock_flag         = 0;
 
 static size_t default_buffer_size = 1024 * 64 * 16 * 2;
 static size_t max_buffer_size     = 1024 * 1024 * 1024;
@@ -57,6 +58,7 @@ int main(int argc, char *argv[]) {
             {"unsafe",        no_argument, &unsafe_flag,        1},
             {"verbose",       no_argument, &verbose_flag,       1},
             {"version",       no_argument, &version_flag,       1},
+            {"wlock",         no_argument, &wlock_flag,         1},
             // Indexed options
             {"file",          required_argument, NULL, 'f'},
             {"buffer-size",   required_argument, NULL, 'b'},
@@ -103,7 +105,7 @@ int main(int argc, char *argv[]) {
         "\n"
         "    baton-put [--file <JSON file>] [--silent]\n"
         "              [--unbuffered] [--unsafe]\n"
-        "              [--verbose] [--version]\n"
+        "              [--verbose] [--version] [--wlock]\n"
         "\n"
         "Description\n"
         "    Puts the contents of files into data objects described in a\n"
@@ -118,7 +120,9 @@ int main(int argc, char *argv[]) {
         "    --unbuffered    Flush print operations for each JSON object.\n"
         "    --unsafe        Permit unsafe relative iRODS paths.\n"
         "    --verbose       Print verbose messages to STDERR.\n"
-        "    --version       Print the version number and exit.\n";
+        "    --version       Print the version number and exit.\n"
+        "    --wlock         Enable server-side advisory write locking.\n"
+        "                    Optional, defaults to false.\n";
 
     if (help_flag) {
         printf("%s\n",help);
@@ -129,6 +133,8 @@ int main(int argc, char *argv[]) {
         printf("%s\n", VERSION);
         exit(0);
     }
+
+    if (wlock_flag) flags = flags | WRITE_LOCK;
 
     if (debug_flag)   set_log_threshold(DEBUG);
     if (verbose_flag) set_log_threshold(NOTICE);
@@ -146,7 +152,8 @@ int main(int argc, char *argv[]) {
         logmsg(DEBUG, "Single-server mode, falling back to operation 'write'");
 
         if (buffer_size > max_buffer_size) {
-            logmsg(WARN, "Requested transfer buffer size %zu exceeds maximum of "
+            logmsg(WARN,
+                   "Requested transfer buffer size %zu exceeds maximum of "
                    "%zu. Setting buffer size to %zu",
                    buffer_size, max_buffer_size, max_buffer_size);
             buffer_size = max_buffer_size;

--- a/src/operations.c
+++ b/src/operations.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2017 Genome Research Ltd. All rights reserved.
+ * Copyright (C) 2017, 2018 Genome Research Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -224,7 +224,8 @@ json_t *baton_json_dispatch_op(rodsEnv *env, rcComm_t *conn, json_t *envelope,
     else if (str_equals(op, JSON_PUT_OP, MAX_STR_LEN)) {
         logmsg(DEBUG, "Dispatching to operation '%s'", op);
         if (args_copy.flags & SINGLE_SERVER) {
-            logmsg(DEBUG, "Single-server mode, falling back to operation 'write'");
+            logmsg(DEBUG,
+                   "Single-server mode, falling back to operation 'write'");
             result = baton_json_write_op(env, conn, target, &args_copy, error);
         }
         else {
@@ -478,7 +479,7 @@ json_t *baton_json_write_op(rodsEnv *env, rcComm_t *conn, json_t *target,
         goto error;
     }
 
-    write_data_obj(conn, in, &rods_path, bsize, error);
+    write_data_obj(conn, in, &rods_path, bsize, args->flags, error);
     int status = fclose(in);
 
     if (error->code != 0) goto error;

--- a/src/operations.h
+++ b/src/operations.h
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2016, 2017 Genome Research Ltd. All
- * rights reserved.
+ * Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 Genome Research
+ * Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -86,7 +86,9 @@ typedef enum {
     /** Force an operation */
     FORCE              = 1 << 18,
     /** Avoid any operations that contact servers other than rodshost */
-    SINGLE_SERVER      = 1 << 19
+    SINGLE_SERVER      = 1 << 19,
+    /** USe advisory write lock on server */
+    WRITE_LOCK         = 1 << 20
 } option_flags;
 
 typedef struct operation_args {

--- a/src/read.h
+++ b/src/read.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2014, 2015, 2016, 2017 Genome Research Ltd. All
+ * Copyright (C) 2014, 2015, 2016, 2017, 2018 Genome Research Ltd. All
  * rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -49,13 +49,15 @@ typedef struct data_obj_file {
  *
  * @param[in]  conn       An open iRODS connection.
  * @param[in]  rods_path  An iRODS data object path.
- * @param[in]  flags      O_RDONLY or O_WRONLY.
- * @parem[out] error      An error report struct.
+ * @param[in]  open_flag  O_RDONLY or O_WRONLY.
+ * @param[in]  flags      WRITE_LOCK to use an advisory lock server-side.
+ *                        Optional.
+ * @param[out] error      An error report struct.
  *
  * @return A new struct, which must be freed by the caller.
  */
 data_obj_file_t *open_data_obj(rcComm_t *conn, rodsPath_t *rods_path,
-                               int flags, baton_error_t *error);
+                               int open_flag, int flags, baton_error_t *error);
 
 int close_data_obj(rcComm_t *conn, data_obj_file_t *obj_file);
 

--- a/src/write.h
+++ b/src/write.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2014, 2015, 2016, 2017 Genome Research Ltd. All
+ * Copyright (C) 2014, 2015, 2016, 2017, 2018 Genome Research Ltd. All
  * rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -34,7 +34,8 @@
  * @param[in]  obj_file    A local file name.
  * @param[in]  rods_path   An iRODS data object path.
  * @param[in]  flags       CALCULATE_CHECKSUM to calculate a checksum on
-                           the server side. Optional.
+                           the server side. WRITE_LOCK to use an advisory
+                           lock server-side. Optional.
  * @param[out] error       An error report struct.
  *
  * @return The number of bytes copied in total.
@@ -63,11 +64,13 @@ size_t write_chunk(rcComm_t *conn, char *buffer, data_obj_file_t *obj_file,
  * @param[in]  in          File to read from.
  * @param[in]  rods_path   An iRODS data object path.
  * @param[in]  buffer_size The number of bytes to copy at one time.
+ * @param[in]  flags       WRITE_LOCK to use an advisory lock server-side.
+                           Optional.
  * @param[out] error       An error report struct.
  *
  * @return The number of bytes copied in total.
  */
 size_t write_data_obj(rcComm_t *conn, FILE *in, rodsPath_t *rods_path,
-                      size_t buffer_size, baton_error_t *error);
+                      size_t buffer_size, int flags, baton_error_t *error);
 
 #endif // _BATON_WRITE_H

--- a/tests/check_baton.c
+++ b/tests/check_baton.c
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2016 Genome Research Ltd. All
- * rights reserved.
+ * Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 Genome Research
+ * Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1885,7 +1885,7 @@ START_TEST(test_slurp_data_obj) {
     for (int i = 0; i < 10; i++) {
         baton_error_t open_error;
         data_obj_file_t *obj = open_data_obj(conn, &rods_obj_path,
-                                             O_RDONLY, &open_error);
+                                             O_RDONLY, flags, &open_error);
         ck_assert_int_eq(open_error.code, 0);
 
         baton_error_t slurp_error;
@@ -2005,7 +2005,8 @@ START_TEST(test_write_data_obj) {
         baton_error_t write_error;
         FILE *in = fopen(file_path, "r");
         size_t num_written = write_data_obj(conn, in, &rods_obj_path,
-                                            buffer_sizes[i], &write_error);
+                                            buffer_sizes[i], flags,
+                                            &write_error);
         ck_assert_int_eq(write_error.code, 0);
         ck_assert_int_eq(num_written, 10240);
         ck_assert_int_eq(fclose(in), 0);


### PR DESCRIPTION
@kript, @dkj here's a branch with a `--wlock` CLI option. I've labelled it WIP because it may not be necessary. I've again investigated logs (Perl wrapper and baton) for multiple concurrent `put` operations, so if any occur they must be at the granularity of LSF jobs. However, we have pre-exec jobs per run to stop that happening.