### PR TITLE
Set up a test matrix with iRODS 4.1.* and 4.2.* Docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,13 @@ compiler: gcc
 env:
   global:
     - CK_DEFAULT_TIMEOUT=20
+  matrix:
+    - DOCKER_IMAGE=wsinpg/ub-16.04-irods-4.2:latest
+    - DOCKER_IMAGE=wsinpg/ub-12.04-irods-4.1:latest
 
 before_install:
-  - docker pull wsinpg/ub-16.04-irods-4.2
-  - docker run -d -p 1247:1247 wsinpg/ub-16.04-irods-4.2
+  - docker pull "$DOCKER_IMAGE"
+  - docker run -d -p 1247:1247 "$DOCKER_IMAGE"
   - docker ps -a
   - ./scripts/travis_before_install.sh
 

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -20,4 +20,4 @@ autoreconf -fi
 
 export LD_LIBRARY_PATH="$CONDA_ENV/lib"
 
-make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-test-resource=testResc CPPFLAGS=\"$CPPFLAGS\" LDFLAGS=\"$LDFLAGS\""
+make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-test-resource=demoResc CPPFLAGS=\"$CPPFLAGS\" LDFLAGS=\"$LDFLAGS\""


### PR DESCRIPTION
Set up a test matrix with iRODS 4.1.* and 4.2.* Docker images.

Changed the iRODS resources used in testing. The Docker images use
testResc as a default resource. Tests that create replicates using
irepl use demoResc as the second replicate.