### PR TITLE
Made changes to support unmarshalling baton JSON by Go:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,6 @@ install:
 
 script:
   - ./scripts/travis_script.sh
+
+after_failure:
+  - cat ./tests/check_baton.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ script:
   - ./scripts/travis_script.sh
 
 after_failure:
-  - cat ./tests/check_baton.log
+  - cat ./baton*/_build/tests/check_baton.log

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -156,8 +156,13 @@ The ``baton`` programs are:
 
 * `baton-do`_
 
-  Perform a mixture of list, chmod, get, put, metamod or metaquery
-  ``baton`` operations specified by arguments supplied as JSON.
+  Perform a mixture of "list", "chmod", "get", "put", "metamod" and
+  "metaquery" ``baton`` operations specified by arguments supplied as
+  JSON.
+
+  ``baton-do`` supports additional operations currently unavailable in
+  the other programs, namely: "remove" (remove a data object), "mkdir"
+  and "rmdir" (create and remove collections, optionally recursively).
 
 All of the programs are designed to accept a stream of JSON objects,
 one for each operation on a collection or data object. After each

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -788,6 +788,13 @@ Options
    Silence error messages.
 
 .. program:: baton-do
+.. option:: --no-error
+
+   Do not report iRODS errors by exiting with a non-zero error code. In
+   this mode errors are reported only in-band of the JSON messages
+   written to STDOUT.
+            
+.. program:: baton-do
 .. option:: --unbuffered
 
   Flush output after each JSON object is processed.

--- a/src/baton-do.c
+++ b/src/baton-do.c
@@ -29,6 +29,7 @@
 
 static int debug_flag         = 0;
 static int help_flag          = 0;
+static int no_error_flag      = 0;
 static int silent_flag        = 0;
 static int single_server_flag = 0;
 static int unbuffered_flag    = 0;
@@ -52,6 +53,7 @@ int main(int argc, char *argv[]) {
             // Flag options
             {"debug",         no_argument, &debug_flag,         1},
             {"help",          no_argument, &help_flag,          1},
+            {"no-error",      no_argument, &no_error_flag,      1},
             {"silent",        no_argument, &silent_flag,        1},
             {"single-server", no_argument, &single_server_flag, 1},
             {"unbuffered",    no_argument, &unbuffered_flag,    1},
@@ -128,6 +130,9 @@ int main(int argc, char *argv[]) {
         "                    10 minutes.\n"
         "    --file          The JSON file describing the operations.\n"
         "                    Optional, defaults to STDIN.\n"
+        "    --no-error      Do not return a non-zero exit code on iRODS\n"
+        "                    errors. Errors will still be reported in-band\n"
+        "                    as JSON responses.\n"
         "    --silent        Silence error messages.\n"
         "    --single-server Only connect to a single iRODS server\n"
         "    --unbuffered    Flush print operations for each JSON object.\n"
@@ -168,7 +173,7 @@ int main(int argc, char *argv[]) {
     int status = do_operation(input, baton_json_dispatch_op, &args);
     if (input != stdin) fclose(input);
 
-    if (status != 0) exit_status = 5;
+    if (status != 0 && !no_error_flag) exit_status = 5;
 
     exit(exit_status);
 }

--- a/src/json.h
+++ b/src/json.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2017 Genome Research Ltd. All
+ * Copyright (C) 2013, 2014, 2015, 2017, 2019 Genome Research Ltd. All
  * rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -96,6 +96,8 @@
 // baton operations
 #define JSON_TARGET_KEY            "target"
 #define JSON_RESULT_KEY            "result"
+#define JSON_SINGLE_RESULT_KEY     "single"
+#define JSON_MULTIPLE_RESULT_KEY   "multiple"
 #define JSON_OP_KEY                "operation"
 #define JSON_OP_SHORT_KEY          "op"
 
@@ -317,6 +319,17 @@ int add_replicates(json_t *object, json_t *replicates, baton_error_t *error);
 
 int add_checksum(json_t *object, json_t *checksum, baton_error_t *error);
 
+/**
+ * Modify a JSON object by adding a property whose value is the result
+ * of an operation. The property key will depend on the type of of the
+ * value.
+ *
+ * @param[object]            A JSON object.
+ * @param[result]            A JSON object.
+ * @param[out] error         An error report struct.
+ *
+ * @return A JSON array on success, NULL on error./
+ */
 int add_result(json_t *object, json_t *result, baton_error_t *error);
 
 int add_error_report(json_t *target, baton_error_t *error);

--- a/src/json.h
+++ b/src/json.h
@@ -109,6 +109,9 @@
 #define JSON_METAQUERY_OP          "metaquery"
 #define JSON_PUT_OP                "put"
 #define JSON_MOVE_OP               "move"
+#define JSON_RM_OP                 "remove"
+#define JSON_MKCOLL_OP             "mkdir"
+#define JSON_RMCOLL_OP             "rmdir"
 
 #define JSON_OP_ARGS_KEY           "arguments"
 #define JSON_OP_ARGS_SHORT_KEY     "args"

--- a/src/json_query.c
+++ b/src/json_query.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2016 Genome Research Ltd. All
+ * Copyright (C) 2013, 2014, 2015, 2016, 2019 Genome Research Ltd. All
  * rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -846,7 +846,7 @@ genQueryInp_t *prepare_json_tps_search(genQueryInp_t *query_in,
             goto error;
         }
 
-        char *raw_timestamp = parse_timestamp(iso_timestamp, ISO8601_FORMAT);
+        char *raw_timestamp = parse_timestamp(iso_timestamp, RFC3339_FORMAT);
         if (!raw_timestamp) {
             set_baton_error(error, CAT_INVALID_ARGUMENT,
                             "Invalid timestamp at position %d of %d, "
@@ -1034,12 +1034,12 @@ json_t *add_tps_json_object(rcComm_t *conn, json_t *object,
             if (error->code != 0) goto error;
 
             json_t *iso_created =
-                make_timestamp(JSON_CREATED_KEY, created, ISO8601_FORMAT,
+                make_timestamp(JSON_CREATED_KEY, created, RFC3339_FORMAT,
                                repl_num, error);
             if (error->code != 0) goto error;
 
             json_t *iso_modified =
-                make_timestamp(JSON_MODIFIED_KEY, modified, ISO8601_FORMAT,
+                make_timestamp(JSON_MODIFIED_KEY, modified, RFC3339_FORMAT,
                                repl_num, error);
             if (error->code != 0) goto error;
 

--- a/src/log.c
+++ b/src/log.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2014 Genome Research Ltd. All rights reserved.
+ * Copyright (C) 2014, 2019 Genome Research Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -71,7 +71,7 @@ void log_impl(int line, const char *file, char const *function,
         struct tm tm;
         gmtime_r(&t, &tm);
 
-        int status = strftime(buffer, sizeof buffer, ISO8601_FORMAT, &tm);
+        int status = strftime(buffer, sizeof buffer, RFC3339_FORMAT, &tm);
         if (status == 0) {
             fprintf(stderr, "Failed to format timestamp '%s': error %d %s",
                     buffer, errno, strerror(errno));

--- a/src/operations.c
+++ b/src/operations.c
@@ -170,6 +170,11 @@ json_t *baton_json_dispatch_op(rodsEnv *env, rcComm_t *conn, json_t *envelope,
     const char *op = get_operation(envelope, error);
     if (error->code != 0) goto error;
 
+    if (!op) {
+        set_baton_error(error, -1, "No baton operation given");
+        goto error;
+    }
+
     json_t *target = get_operation_target(envelope, error);
     if (error->code != 0) goto error;
 
@@ -379,10 +384,15 @@ json_t *baton_json_checksum_op(rodsEnv *env, rcComm_t *conn, json_t *target,
     resolve_rods_path(conn, env, &rods_path, path, flags, error);
     if (error->code != 0) goto error;
 
-    result = checksum_data_obj(conn, &rods_path, flags, error);
+    json_t *checksum = checksum_data_obj(conn, &rods_path, flags, error);
+    if (error->code != 0) goto error;
+
+    add_checksum(target, checksum, error);
     if (error->code != 0) goto error;
 
     if (path) free(path);
+
+    result = target;
 
     return result;
 

--- a/src/operations.c
+++ b/src/operations.c
@@ -1,5 +1,6 @@
 /**
- * Copyright (C) 2017, 2018 Genome Research Ltd. All rights reserved.
+ * Copyright (C) 2017, 2018, 2019 Genome Research Ltd. All rights
+ * reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -642,7 +643,7 @@ json_t *baton_json_mkcoll_op(rodsEnv *env, rcComm_t *conn,
                              baton_error_t *error) {
     json_t *result = NULL;
 
-    char *path = json_to_path(target, error);
+    char *path = json_to_collection_path(target, error);
     if (error->code != 0) goto error;
 
     rodsPath_t rods_path;
@@ -670,7 +671,7 @@ json_t *baton_json_rmcoll_op(rodsEnv *env, rcComm_t *conn,
                              baton_error_t *error) {
     json_t *result = NULL;
 
-    char *path = json_to_path(target, error);
+    char *path = json_to_collection_path(target, error);
     if (error->code != 0) goto error;
 
     rodsPath_t rods_path;

--- a/src/operations.c
+++ b/src/operations.c
@@ -453,6 +453,8 @@ json_t *baton_json_metamod_op(rodsEnv *env, rcComm_t *conn, json_t *target,
     if (rods_path.rodsObjStat) free(rods_path.rodsObjStat);
     if (path) free(path);
 
+    result = target;
+
     return result;
 
 error:

--- a/src/operations.c
+++ b/src/operations.c
@@ -363,6 +363,11 @@ json_t *baton_json_checksum_op(rodsEnv *env, rcComm_t *conn, json_t *target,
                                operation_args_t *args, baton_error_t *error) {
     json_t *result = NULL;
     char *path     = NULL;
+    if (!represents_data_object(target)) {
+        set_baton_error(error, CAT_INVALID_ARGUMENT,
+                        "cannot checksum a non-data-object");
+        goto error;
+    }
 
     path = json_to_path(target, error);
     if (error->code != 0) goto error;
@@ -502,8 +507,14 @@ error:
 json_t *baton_json_write_op(rodsEnv *env, rcComm_t *conn, json_t *target,
                             operation_args_t *args, baton_error_t *error) {
     json_t *result = NULL;
+    char *path = NULL;
+    if (!represents_data_object(target)) {
+        set_baton_error(error, CAT_INVALID_ARGUMENT,
+                        "cannot write a data object given a non-data-object");
+        goto error;
+    }
 
-    char *path = json_to_path(target, error);
+    path = json_to_path(target, error);
     if (error->code != 0) goto error;
 
     rodsPath_t rods_path;
@@ -613,8 +624,15 @@ json_t *baton_json_rm_op(rodsEnv *env, rcComm_t *conn,
                          json_t *target, operation_args_t *args,
                          baton_error_t *error) {
     json_t *result = NULL;
+    char *path = NULL;
 
-    char *path = json_to_path(target, error);
+    if (!represents_data_object(target)) {
+        set_baton_error(error, CAT_INVALID_ARGUMENT,
+                        "cannot remove a non-data-object");
+        goto error;
+    }
+
+    path = json_to_path(target, error);
     if (error->code != 0) goto error;
 
     rodsPath_t rods_path;
@@ -635,15 +653,20 @@ error:
     if (path) free(path);
 
     return result;
-
 }
 
 json_t *baton_json_mkcoll_op(rodsEnv *env, rcComm_t *conn,
                              json_t *target, operation_args_t *args,
                              baton_error_t *error) {
     json_t *result = NULL;
+    char *path = NULL;
+    if (represents_data_object(target)) {
+        set_baton_error(error, CAT_INVALID_ARGUMENT,
+                        "cannot make a collection given a data object");
+        goto error;
+    }
 
-    char *path = json_to_collection_path(target, error);
+    path = json_to_collection_path(target, error);
     if (error->code != 0) goto error;
 
     rodsPath_t rods_path;
@@ -670,8 +693,14 @@ json_t *baton_json_rmcoll_op(rodsEnv *env, rcComm_t *conn,
                              json_t *target, operation_args_t *args,
                              baton_error_t *error) {
     json_t *result = NULL;
+    char *path = NULL;
+    if (represents_data_object(target)) {
+        set_baton_error(error, CAT_INVALID_ARGUMENT,
+                        "cannot remove a collection given a data object");
+        goto error;
+    }
 
-    char *path = json_to_collection_path(target, error);
+    path = json_to_collection_path(target, error);
     if (error->code != 0) goto error;
 
     rodsPath_t rods_path;

--- a/src/operations.c
+++ b/src/operations.c
@@ -239,6 +239,7 @@ json_t *baton_json_dispatch_op(rodsEnv *env, rcComm_t *conn, json_t *envelope,
     }
     else if (str_equals(op, JSON_CHECKSUM_OP, MAX_STR_LEN)) {
         result = baton_json_checksum_op(env, conn, target, &args_copy, error);
+        if (error->code != 0) goto error;
 
         if (args_copy.flags & PRINT_CHECKSUM) {
             result = add_checksum_json_object(conn, result, error);
@@ -266,6 +267,7 @@ json_t *baton_json_dispatch_op(rodsEnv *env, rcComm_t *conn, json_t *envelope,
         else {
             result = baton_json_put_op(env, conn, target, &args_copy, error);
         }
+        if (error->code != 0) goto error;
 
         if (args_copy.flags & PRINT_CHECKSUM) {
             result = add_checksum_json_object(conn, result, error);

--- a/src/operations.h
+++ b/src/operations.h
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 Genome Research
- * Ltd. All rights reserved.
+ * Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019 Genome
+ * Research Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -172,6 +172,18 @@ json_t *baton_json_write_op(rodsEnv *env, rcComm_t *conn,
 json_t *baton_json_move_op(rodsEnv *env, rcComm_t *conn,
                            json_t *target, operation_args_t *args,
                            baton_error_t *error);
+
+json_t *baton_json_rm_op(rodsEnv *env, rcComm_t *conn,
+                         json_t *target, operation_args_t *args,
+                         baton_error_t *error);
+
+json_t *baton_json_mkcoll_op(rodsEnv *env, rcComm_t *conn,
+                             json_t *target, operation_args_t *args,
+                             baton_error_t *error);
+
+json_t *baton_json_rmcoll_op(rodsEnv *env, rcComm_t *conn,
+                             json_t *target, operation_args_t *args,
+                             baton_error_t *error);
 
 int check_str_arg(const char *arg_name, const char *arg_value,
                   size_t arg_size, baton_error_t *error);

--- a/src/read.c
+++ b/src/read.c
@@ -496,6 +496,8 @@ json_t *checksum_data_obj(rcComm_t *conn, rodsPath_t *rods_path,
     dataObjInp_t obj_chk_in;
     int status;
 
+    init_baton_error(error);
+
     memset(&obj_chk_in, 0, sizeof obj_chk_in);
     obj_chk_in.openFlags = O_RDONLY;
 

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -1,5 +1,6 @@
 /**
- * Copyright (C) 2013, 2014 Genome Research Ltd. All rights reserved.
+ * Copyright (C) 2013, 2014, 2019 Genome Research Ltd. All rights
+ * reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,6 +27,7 @@
 #define MAX_STR_LEN (1024 * 1024 * 1024)
 
 #define ISO8601_FORMAT "%Y-%m-%dT%H:%M:%S"
+#define RFC3339_FORMAT "%Y-%m-%dT%H:%M:%SZ"
 
 int str_starts_with(const char *str, const char *prefix, size_t max_len);
 

--- a/src/write.h
+++ b/src/write.h
@@ -73,4 +73,13 @@ size_t write_chunk(rcComm_t *conn, char *buffer, data_obj_file_t *obj_file,
 size_t write_data_obj(rcComm_t *conn, FILE *in, rodsPath_t *rods_path,
                       size_t buffer_size, int flags, baton_error_t *error);
 
+int remove_data_object(rcComm_t *conn, rodsPath_t *rods_path, int flags,
+                      baton_error_t *error);
+
+int create_collection(rcComm_t *conn, rodsPath_t *rods_path, int flags,
+                      baton_error_t *error);
+
+int remove_collection(rcComm_t *conn, rodsPath_t *rods_path, int flags,
+                      baton_error_t *error);
+
 #endif // _BATON_WRITE_H

--- a/tests/check_baton.c
+++ b/tests/check_baton.c
@@ -2082,6 +2082,10 @@ START_TEST(test_put_data_obj) {
                       flags, &result_error);
     ck_assert_int_eq(result_error.code, 0);
 
+    baton_error_t checksum_error;
+    checksum_data_obj(conn, &result_obj_path, flags, &checksum_error);
+    ck_assert_int_eq(checksum_error.code, 0);
+
     baton_error_t list_error;
     json_t *result = list_path(conn, &result_obj_path, PRINT_CHECKSUM,
                                &list_error);

--- a/tests/check_baton.c
+++ b/tests/check_baton.c
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018 Genome Research
- * Ltd. All rights reserved.
+ * Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019 Genome
+ * Research Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1178,7 +1178,7 @@ START_TEST(test_search_metadata_tps_obj) {
     const char *raw_created = get_created_timestamp(first_tps, &ts_error);
     ck_assert_int_eq(ts_error.code, 0);
 
-    char *iso_created = format_timestamp(raw_created, ISO8601_FORMAT);
+    char *iso_created = format_timestamp(raw_created, RFC3339_FORMAT);
 
     // Should not find any results for data objects created before the
     // root collection of the test data was created
@@ -1767,7 +1767,7 @@ START_TEST(test_contains_avu) {
 END_TEST
 
 // Can we test for JSON representation of a collection?
-START_TEST(test_represents_collection) {
+START_TEST(test_represents_coll) {
     json_t *col = json_pack("{s:s}", JSON_COLLECTION_KEY, "foo");
     json_t *obj = json_pack("{s:s, s:s}",
                             JSON_COLLECTION_KEY,  "foo",
@@ -1782,7 +1782,7 @@ START_TEST(test_represents_collection) {
 END_TEST
 
 // Can we test for JSON representation of a data object?
-START_TEST(test_represents_data_object) {
+START_TEST(test_represents_data_obj) {
     json_t *col = json_pack("{s:s}", JSON_COLLECTION_KEY, "foo");
     json_t *obj = json_pack("{s:s, s:s}",
                             JSON_COLLECTION_KEY,  "foo",
@@ -1797,7 +1797,7 @@ START_TEST(test_represents_data_object) {
 END_TEST
 
 // Can we test for JSON representation of a directory?
-START_TEST(test_represents_directory) {
+START_TEST(test_represents_dir) {
     json_t *dir  = json_pack("{s:s}", JSON_DIRECTORY_KEY, "foo");
     json_t *file = json_pack("{s:s, s:s}",
                              JSON_DIRECTORY_KEY, "foo",
@@ -2111,6 +2111,116 @@ START_TEST(test_put_data_obj) {
     unlink(template);
 
     if (conn) rcDisconnect(conn);
+}
+END_TEST
+
+// Can we remove a data object
+START_TEST(test_remove_data_obj) {
+    option_flags flags = 0;
+    rodsEnv env;
+    rcComm_t *conn = rods_login(&env);
+
+    char rods_root[MAX_PATH_LEN];
+    set_current_rods_root(TEST_COLL, rods_root);
+
+    char obj_path[MAX_PATH_LEN];
+    snprintf(obj_path, MAX_PATH_LEN, "%s/f1.txt", rods_root);
+
+    rodsPath_t rods_path;
+    baton_error_t resolve_error;
+    int resolve_status =
+        resolve_rods_path(conn, &env, &rods_path, obj_path,
+                          flags, &resolve_error);
+    ck_assert_int_eq(resolve_error.code, 0);
+    ck_assert_int_eq(resolve_status, EXIST_ST);
+    ck_assert_int_eq(rods_path.objType, DATA_OBJ_T);
+
+    baton_error_t remove_error;
+    int remove_status =
+        remove_data_object(conn, &rods_path, flags, &remove_error);
+    ck_assert_int_eq(remove_error.code, 0);
+    ck_assert_int_eq(remove_status, 0);
+
+    resolve_status =
+        resolve_rods_path(conn, &env, &rods_path, obj_path,
+                          flags, &resolve_error);
+    ck_assert_int_eq(resolve_error.code, 0);
+    ck_assert_int_ne(resolve_status, EXIST_ST);
+    ck_assert_int_ne(rods_path.objType, DATA_OBJ_T);
+}
+END_TEST
+
+// Can we create a collection?
+START_TEST(test_create_coll) {
+    option_flags flags = RECURSIVE;
+    rodsEnv env;
+    rcComm_t *conn = rods_login(&env);
+
+    char rods_root[MAX_PATH_LEN];
+    set_current_rods_root(TEST_COLL, rods_root);
+
+    char coll_path[MAX_PATH_LEN];
+    snprintf(coll_path, MAX_PATH_LEN, "%s/a/b/c", rods_root);
+
+    rodsPath_t rods_coll_path;
+    baton_error_t resolve_error;
+    int resolve_status =
+        resolve_rods_path(conn, &env, &rods_coll_path, coll_path,
+                          flags, &resolve_error);
+    ck_assert_int_eq(resolve_error.code, 0);
+    ck_assert_int_ne(rods_coll_path.objType, COLL_OBJ_T); // Not present
+
+    baton_error_t create_error;
+    int create_status =
+        create_collection(conn, &rods_coll_path, flags, &create_error);
+    ck_assert_int_eq(create_error.code, 0);
+    ck_assert_int_eq(create_status, 0);
+
+    resolve_rods_path(conn, &env, &rods_coll_path, coll_path,
+                      flags, &resolve_error);
+
+    ck_assert_int_eq(rods_coll_path.objType, COLL_OBJ_T); // Created
+}
+END_TEST
+
+// Can we remove a collection?
+START_TEST(test_remove_coll) {
+    option_flags flags = RECURSIVE;
+    rodsEnv env;
+    rcComm_t *conn = rods_login(&env);
+
+    char rods_root[MAX_PATH_LEN];
+    set_current_rods_root(TEST_COLL, rods_root);
+
+    char coll_path[MAX_PATH_LEN];
+    snprintf(coll_path, MAX_PATH_LEN, "%s/a/b/c", rods_root);
+
+    rodsPath_t rods_coll_path;
+    baton_error_t resolve_error;
+    resolve_rods_path(conn, &env, &rods_coll_path, coll_path,
+                      flags, &resolve_error);
+    ck_assert_int_eq(resolve_error.code, 0);
+
+    baton_error_t create_error;
+    int create_status =
+        create_collection(conn, &rods_coll_path, flags, &create_error);
+    ck_assert_int_eq(create_error.code, 0);
+    ck_assert_int_eq(create_status, 0);
+
+    resolve_rods_path(conn, &env, &rods_coll_path, coll_path,
+                      flags, &resolve_error);
+    ck_assert_int_eq(rods_coll_path.objType, COLL_OBJ_T); // Present
+
+    baton_error_t remove_error;
+    int remove_status =
+        remove_collection(conn, &rods_coll_path, flags, &remove_error);
+    ck_assert_int_eq(remove_error.code, 0);
+    ck_assert_int_eq(remove_status, 0);
+
+    resolve_rods_path(conn, &env, &rods_coll_path, coll_path,
+                      flags, &resolve_error);
+    ck_assert_int_eq(resolve_error.code, 0);
+    ck_assert_int_ne(rods_coll_path.objType, COLL_OBJ_T); // Not present
 }
 END_TEST
 
@@ -2543,14 +2653,17 @@ Suite *baton_suite(void) {
     tcase_add_test(read_write, test_ingest_data_obj);
     tcase_add_test(read_write, test_write_data_obj);
     tcase_add_test(read_write, test_put_data_obj);
+    tcase_add_test(read_write, test_remove_data_obj);
+    tcase_add_test(read_write, test_create_coll);
+    tcase_add_test(read_write, test_remove_coll);
 
     TCase *json = tcase_create("json");
     tcase_add_unchecked_fixture(json, setup, teardown);
     tcase_add_checked_fixture(json, basic_setup, basic_teardown);
 
-    tcase_add_test(json, test_represents_collection);
-    tcase_add_test(json, test_represents_data_object);
-    tcase_add_test(json, test_represents_directory);
+    tcase_add_test(json, test_represents_coll);
+    tcase_add_test(json, test_represents_data_obj);
+    tcase_add_test(json, test_represents_dir);
     tcase_add_test(json, test_represents_file);
     tcase_add_test(json, test_json_to_path);
     tcase_add_test(json, test_json_to_local_path);


### PR DESCRIPTION
JSON object and JSON array results now appear under distinct keys to
allow automatic unmarshalling.

Timestamps are formatted as RFC3339, which is the default for Go
unmarshalling. As baton used ISO8601 UTC previously, this turned out
to be possible simply by appending 'Z' to the existing
format. N.B. strftime doesn't support RFC3339 timezone formats!

This is a breaking change to the JSON output format, so will require bumping the major version.