### PR TITLE
Memory management bugfix and refactor

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -212,6 +212,8 @@ json_t *list_checksum(rcComm_t *conn, rodsPath_t *rods_path,
     results = do_query(conn, query_in, obj_format.labels, error);
     if (error->code != 0) goto error;
 
+    free_query_input(query_in);
+
     if (json_array_size(results) != 1) {
         set_baton_error(error, -1, "Expected 1 data object result but found %d",
                         json_array_size(results));
@@ -220,7 +222,8 @@ json_t *list_checksum(rcComm_t *conn, rodsPath_t *rods_path,
 
     json_t *obj = json_array_get(results, 0);
     json_t *checksum = json_incref(json_object_get(obj, JSON_CHECKSUM_KEY));
-    json_decref(results);
+
+    if (results) json_decref(results);
 
     return checksum;
 

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -1,5 +1,6 @@
 /**
- * Copyright (C) 2013, 2014 Genome Research Ltd. All rights reserved.
+ * Copyright (C) 2013, 2014, 2020 Genome Research Ltd. All rights
+ * reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -158,7 +159,7 @@ size_t parse_size(const char *str) {
     if (errno != 0) {
         logmsg(ERROR, "Failed recognise '%s' as a number: error %d %s",
                str, errno, strerror(errno));
-        goto error;
+        goto finally;
     }
 
     if (end == str) {
@@ -170,9 +171,7 @@ size_t parse_size(const char *str) {
 
     logmsg(DEBUG, "Parsed size of %", value);
 
-    return value;
-
-error:
+finally:
     return value;
 }
 

--- a/tests/scripts/valgrind/baton-do-valgrind.sh
+++ b/tests/scripts/valgrind/baton-do-valgrind.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# This script wraps baton-do so that it will run under
+# Valgrind. Symlink this script in place of your baton-do executable
+# when testing your iRODS wrapper (e.g. perl-irods-wrap or extendo),
+# making sure that the real baton-do it not on your PATH.
+#
+#You can then run your iRODS wrapper tests (or even higher level tests
+# that use the wrapper), knowing that the baton code underneath is
+# being tested for memory leaks.
+#
+# The iRODS libraries always generate some leak errors, so a Valgrind
+# suppressions file is used to mute these.
+
+set -e
+
+LOG_DIR=${LOG_DIR:-"$PWD"}
+SUPPRESSIONS=${SUPPRESSIONS:-"$PWD/suppressions/baton.supp"}
+WRAPPED=${WRAPPED:-baton-do}
+
+mkdir -p "$LOG_DIR"
+
+valgrind --error-exitcode=1 \
+         --leak-check=full \
+         --show-leak-kinds=definite,possible \
+         --suppressions="$SUPPRESSIONS" \
+         --log-file="$LOG_DIR/baton-do.$BASHPID.log" \
+         "$WRAPPED" -f /dev/stdin "$@" >/dev/stdout

--- a/tests/scripts/valgrind/baton.supp
+++ b/tests/scripts/valgrind/baton.supp
@@ -1,0 +1,14 @@
+{
+   <iRODS addKeyVal>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:addKeyVal
+}
+{
+   <iRODS initPackedOutput>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:initPackedOutput
+}


### PR DESCRIPTION
These changes address two related problems with baton, firstly
inconsistent memory management on errors, leading to segfaults and
secondly, memory management code duplication between error and
non-error code paths.

`init_rods_path` (called from `resolve_rods_path`) is no longer
responsible for memset'ing the `rods_path` struct. Now the caller does
this immediately after declaring. This in repetitive, but is simple
and eliminates the most common class of bug found recently in
baton (segfaults due to uninitialised memory on the error handling
code path).

Where non-error and error code paths share operations and return
values, these have been combined with a new label 'finally'.

As the changes are extensive, the API has been tested with
Valgrind. Included is a new wrapper script for baton-do that can be
used where higher level APIs run a baton-do child process. This allows
the specific baton-do functions used by the higher level API to be run
under Valgrind.

The Valgrind tests revealed an existing memory leak in list_checksum,
which has been fixed.