### PR TITLE
Added a workaround for iRODS issues #5072 and #5081

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,10 @@ compiler: gcc
 env:
   global:
     - CK_DEFAULT_TIMEOUT=20
-  matrix:
-    - DOCKER_IMAGE=wsinpg/ub-16.04-irods-4.2:latest
-    - DOCKER_IMAGE=wsinpg/ub-12.04-irods-4.1:latest
+  jobs:
+    - DOCKER_IMAGE=wsinpg/ub-16.04-irods-4.2:latest CONFIGURE_ARGS="--with-test-resource=testResc --enable-put-workaround"
+    - DOCKER_IMAGE=wsinpg/ub-16.04-irods-4.2:latest CONFIGURE_ARGS="--with-test-resource=testResc"
+    - DOCKER_IMAGE=wsinpg/ub-12.04-irods-4.1:latest CONFIGURE_ARGS="--with-test-resource=testResc"
 
 before_install:
   - docker pull "$DOCKER_IMAGE"

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 	[Upcoming]
 
+	Bugfix: Added a workaround for iRODS bug ###. The workaround
+	requires creating a new connection for every put operation when
+	baton is re-using a connection for multiple operations. The
+	workaround will be active only if baton is compiled with iRODS
+	versions 4.2.7 or 4.2.8.
+
 	Bugfix: exit non-zero when the iRODS plugins cannot be located.
 
 	Bugfix: fix segfault when operations require a path and none

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,11 @@
 	[Upcoming]
 
-	Bugfix: Added a workaround for iRODS bug ###. The workaround
+	Bugfix: Added a workaround for iRODS issue
+	https://github.com/irods/irods/issues/5072. The workaround
 	requires creating a new connection for every put operation when
 	baton is re-using a connection for multiple operations. The
-	workaround will be active only if baton is compiled with iRODS
-	versions 4.2.7 or 4.2.8.
+	workaround will be active only if baton is compiled the configure
+	flag --enable-put-workaround.
 
 	Bugfix: exit non-zero when the iRODS plugins cannot be located.
 

--- a/configure.ac
+++ b/configure.ac
@@ -103,6 +103,7 @@ AS_IF(
 AM_CONDITIONAL(COVERAGE_ENABLED, [test "x${coverage_enabled}" = "xyes"])
 dnl End Lcov
 
+dnl Begin test resource
 TEST_RESOURCE=testResc
 AC_SUBST([TEST_RESOURCE])
 
@@ -113,6 +114,26 @@ AC_ARG_WITH([test-resource],
     TEST_RESOURCE="$with_test_resource"],
    [AC_MSG_NOTICE([using the default iRODS test resource])
     TEST_RESOURCE="testResc"])
+dnl End test resource
+
+dnl Begin put workaround
+dnl See for https://github.com/irods/irods/issues/5072
+wo_url="https://github.com/irods/irods/issues/5072"
+
+AC_ARG_ENABLE([put-workaround],
+  [AS_HELP_STRING([--enable-put-workaround],
+    [Enable workaround for ${wo_url} (default is no)])],
+  [put_workaround_enabled=${enableval}], [put_workaround_enabled=no])
+
+AS_IF([test "x${put_workaround_enabled}" = "xyes"],
+  [AC_MSG_NOTICE([enabled workaround for ${wo_url}])]
+  [AC_DEFINE([ENABLE_PUT_WORKAROUND],
+     [],
+     "Workaround for ${wo_url}")],
+  [])
+AM_CONDITIONAL(PUT_WORKAROUND_ENABLED,
+               [test "x${put_workaround_enabled}" = "xyes"])
+dnl End put workaround
 
 AC_CHECK_LIB([jansson], [json_unpack], [],
              [AC_MSG_ERROR([unable to find libjansson])])

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -15,9 +15,8 @@ LDFLAGS="-L$CONDA_ENV/lib -L$CONDA_ENV/lib/irods/externals"
 
 autoreconf -fi
 
-./configure --with-test-resource=testResc \
-            CPPFLAGS="$CPPFLAGS" LDFLAGS="$LDFLAGS"
+./configure "$CONFIGURE_ARGS" CPPFLAGS="$CPPFLAGS" LDFLAGS="$LDFLAGS"
 
 export LD_LIBRARY_PATH="$CONDA_ENV/lib"
 
-make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-test-resource=demoResc CPPFLAGS=\"$CPPFLAGS\" LDFLAGS=\"$LDFLAGS\""
+make distcheck DISTCHECK_CONFIGURE_FLAGS="$CONFIGURE_ARGS CPPFLAGS=\"$CPPFLAGS\" LDFLAGS=\"$LDFLAGS\""

--- a/src/operations.c
+++ b/src/operations.c
@@ -71,8 +71,7 @@ static int iterate_json(FILE *input, rodsEnv *env, baton_json_op fn,
             connect_time = time(0);
         }
 
-#if IRODS_VERSION_INTEGER && (IRODS_VERSION_INTEGER == 4002007 || \
-                              IRODS_VERSION_INTEGER == 4002008)
+#ifdef ENABLE_PUT_WORKAROUND
 	// If a put operation or dispatch to a put operation are
 	// requested, reconnect first.
 	int drop_conn = 0;
@@ -103,7 +102,7 @@ static int iterate_json(FILE *input, rodsEnv *env, baton_json_op fn,
 	}
 #endif
 
-        baton_error_t error;
+	baton_error_t error;
         json_t *result = fn(env, conn, item, args, &error);
         if (error.code != 0) {
             // On error, add an error report to the input JSON as a

--- a/src/operations.c
+++ b/src/operations.c
@@ -31,6 +31,7 @@ static int iterate_json(FILE *input, rodsEnv *env, baton_json_op fn,
     time_t connect_time = 0;
     int       reconnect = 0; // Set to 1 when reconnecting
     rcComm_t *conn      = NULL;
+    int drop_conn_count = 0;
     int        status   = 0;
 
     while (!feof(input)) {
@@ -69,6 +70,38 @@ static int iterate_json(FILE *input, rodsEnv *env, baton_json_op fn,
             }
             connect_time = time(0);
         }
+
+#if IRODS_VERSION_INTEGER && (IRODS_VERSION_INTEGER == 4002007 || \
+                              IRODS_VERSION_INTEGER == 4002008)
+	// If a put operation or dispatch to a put operation are
+	// requested, reconnect first.
+	int drop_conn = 0;
+	if (fn == baton_json_put_op) {
+	  drop_conn = 1;
+	}
+	else if (fn == baton_json_dispatch_op) {
+	  baton_error_t error;
+	  const char *op = get_operation(item, &error);
+	  // Ignore any error here because there are already checks
+	  // for a valid operation string the dispatch function. We
+	  // only want to know about the successful case at this
+	  // point, so that we can decide if we have a put operation
+	  // and thus need to reconnect first.
+	  if (error.code == 0 && (str_equals(op, JSON_PUT_OP, MAX_STR_LEN))) {
+	    drop_conn = 1;
+	  }
+	}
+
+	if (drop_conn) {
+	  logmsg(INFO, "Reconnecting for put operation workaround");
+	  drop_conn_count++;
+	  rcComm_t *newConn = rods_login(env);
+	  if (!newConn) goto finally;
+
+	  rcDisconnect(conn);
+	  conn = newConn;
+	}
+#endif
 
         baton_error_t error;
         json_t *result = fn(env, conn, item, args, &error);
@@ -113,7 +146,7 @@ static int iterate_json(FILE *input, rodsEnv *env, baton_json_op fn,
         time_t now = time(0);
         double duration = difftime(now, connect_time);
         if (args->max_connect_time > 0 && duration > args->max_connect_time) {
-            logmsg(INFO, "The connection to iRODS open for %d seconds, "
+            logmsg(INFO, "The connection to iRODS was open for %d seconds, "
                    "the maximum allowed is %d; closing the connection to "
                    "reopen a new one", duration, args->max_connect_time);
             rcDisconnect(conn);
@@ -121,6 +154,11 @@ static int iterate_json(FILE *input, rodsEnv *env, baton_json_op fn,
             reconnect = 1;
         }
     } // while
+
+    if (drop_conn_count > 0) {
+      logmsg(WARN, "Reconnected for put operations %d times",
+	     drop_conn_count);
+    }
 
 finally:
     if (conn) rcDisconnect(conn);

--- a/tests/metadata/meta1.imeta
+++ b/tests/metadata/meta1.imeta
@@ -1,29 +1,23 @@
 add -d __IRODS_TEST_ROOT__/f1.txt attr1 value1 units1
 add -d __IRODS_TEST_ROOT__/f2.txt attr1 value1 units1
 add -d __IRODS_TEST_ROOT__/f3.txt attr1 value1 units1
-
 add -d __IRODS_TEST_ROOT__/a/f4.txt attr1 value1 units1
 add -d __IRODS_TEST_ROOT__/a/f5.txt attr1 value1 units1
 add -d __IRODS_TEST_ROOT__/a/f6.txt attr1 value1 units1
-
 add -d __IRODS_TEST_ROOT__/a/x/f7.txt attr1 value1 units1
 add -d __IRODS_TEST_ROOT__/a/x/f8.txt attr1 value1 units1
 add -d __IRODS_TEST_ROOT__/a/x/f9.txt attr1 value1 units1
-
 add -d __IRODS_TEST_ROOT__/a/x/m/f10.txt attr1 value1 units1
 add -d __IRODS_TEST_ROOT__/a/x/m/f11.txt attr1 value1 units1
 add -d __IRODS_TEST_ROOT__/a/x/m/f12.txt attr1 value1 units1
-
 add -C __IRODS_TEST_ROOT__/a attr2 value2 units2
 add -C __IRODS_TEST_ROOT__/a/x attr2 value2 units2
 add -C __IRODS_TEST_ROOT__/a/x/m attr2 value2 units2
-
 add -d __IRODS_TEST_ROOT__/r1.txt a x
 add -d __IRODS_TEST_ROOT__/r1.txt a y
 add -d __IRODS_TEST_ROOT__/r1.txt b x
 add -d __IRODS_TEST_ROOT__/r1.txt b y
 add -d __IRODS_TEST_ROOT__/r1.txt b z
-
 add -d __IRODS_TEST_ROOT__/r1.txt numattr1 1
 add -d __IRODS_TEST_ROOT__/r1.txt numattr1 10
 add -d __IRODS_TEST_ROOT__/r1.txt numattr1 100


### PR DESCRIPTION
See https://github.com/irods/irods/issues/5072

The workaround requires creating a new connection for every put operation
when baton is re-using a connection for multiple operations. The workaround
will be active only if baton is compiled with the `--enable-put-workaround`
configure flag.

Updated test input data to workaround https://github.com/irods/irods/issues/5081