### PR TITLE
Update Travis build for iRODS 4.2.7 and prepare for 4.2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,23 @@ language: c
 
 compiler: gcc
 
+_iRODS_4_2_8: &iRODS_4_2_8
+  env: DOCKER_IMAGE=wsinpg/ub-18.04-irods-4.2.8:latest IRODS_VERSION="4.2.8" CONFIGURE_ARGS="--with-test-resource=replResc"
+
 env:
   global:
     - CK_DEFAULT_TIMEOUT=20
-  jobs:
-    - DOCKER_IMAGE=wsinpg/ub-16.04-irods-4.2:latest CONFIGURE_ARGS="--with-test-resource=testResc --enable-put-workaround"
-    - DOCKER_IMAGE=wsinpg/ub-16.04-irods-4.2:latest CONFIGURE_ARGS="--with-test-resource=testResc"
-    - DOCKER_IMAGE=wsinpg/ub-12.04-irods-4.1:latest CONFIGURE_ARGS="--with-test-resource=testResc"
+
+jobs:
+  include:
+    - env: DOCKER_IMAGE=wsinpg/ub-12.04-irods-4.1:latest IRODS_VERSION="4.1.12" CONFIGURE_ARGS="--with-test-resource=replResc"
+    - env: DOCKER_IMAGE=wsinpg/ub-16.04-irods-4.2.7:latest IRODS_VERSION="4.2.7" CONFIGURE_ARGS="--with-test-resource=replResc --enable-put-workaround"
+    - env: DOCKER_IMAGE=wsinpg/ub-16.04-irods-4.2.7:latest IRODS_VERSION="4.2.7" CONFIGURE_ARGS="--with-test-resource=replResc"
+    - <<: *iRODS_4_2_8
+
+  allow_failures:
+    - <<: *iRODS_4_2_8
+
 
 before_install:
   - docker pull "$DOCKER_IMAGE"
@@ -28,4 +38,5 @@ script:
   - ./scripts/travis_script.sh
 
 after_failure:
-  - cat ./baton*/_build/tests/check_baton.log
+  - ./scripts/travis_failure.sh
+

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 	[Upcoming]
 
+	[2.1.0]
+
 	Bugfix: Added a workaround for iRODS issue
 	https://github.com/irods/irods/issues/5072. The workaround
 	requires creating a new connection for every put operation when

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,15 @@
 	Bugfix: fix segfault when operations require a path and none
 	supplied.
 
+	Add iRODS 4.2.8 to the test matrix.
+
+	Check for both libirods_common and libirods_client for iRODS 4.2.x.
+
+	Use the available replication resource in the test server Docker
+	image, rather than manually irepl to another local resource.
+
+	Use check library from Conda, rather than building from source.
+
 	[2.0.1]
 
 	Bugfix: correct cases where we simply returned the target JSON as

--- a/m4/ax_with_irods.m4
+++ b/m4/ax_with_irods.m4
@@ -31,7 +31,7 @@
 #
 # LICENSE
 #
-# Copyright (C) 2016, 2019 Genome Research Ltd.
+# Copyright (C) 2016, 2019, 2020 Genome Research Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -154,7 +154,11 @@ AC_DEFUN([AX_WITH_IRODS], [
          AC_MSG_RESULT([yes])
          AC_DEFINE([HAVE_IRODS], [1], [iRODS >=4.2.x])
 
-         AC_CHECK_LIB([irods_client], [getRodsEnv], [],
+         AC_CHECK_LIB([irods_common], [getRodsEnv], [],
+                     [AC_MSG_ERROR([unable to find libirods_common])],
+                     [])
+
+         AC_CHECK_LIB([irods_client], [getRodsObjType], [],
                      [AC_MSG_ERROR([unable to find libirods_client])],
                      [-lirods_common])
 

--- a/scripts/travis_failure.sh
+++ b/scripts/travis_failure.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+. ~/miniconda/etc/profile.d/conda.sh
+conda activate travis
+ilsresc
+ils -Lr
+cat ./baton*/_build/*/tests/check_baton.log

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -19,10 +19,12 @@ conda install -y python
 pip install sphinx==2.4.0
 
 conda config --add channels https://dnap.cog.sanger.ac.uk/npg/conda/devel/generic/
+conda config --append channels conda-forge
 
+conda install -y check
 conda install -y libjansson-dev
-conda install -y irods-dev
-conda install -y irods-icommands
+conda install -y irods-dev="$IRODS_VERSION"
+conda install -y irods-icommands="$IRODS_VERSION"
 
 mkdir -p ~/.irods
 cat <<EOF > ~/.irods/irods_environment.json
@@ -33,16 +35,7 @@ cat <<EOF > ~/.irods/irods_environment.json
     "irods_zone_name": "testZone",
     "irods_home": "/testZone/home/irods",
     "irods_plugins_home": "$HOME/miniconda/envs/travis/lib/irods/plugins/",
-    "irods_default_resource": "testResc"
+    "irods_default_resource": "replResc"
 }
 EOF
 
-# Check
-wget http://downloads.sourceforge.net/project/check/check/0.9.14/check-0.9.14.tar.gz -O /tmp/check-0.9.14.tar.gz
-tar xfz /tmp/check-0.9.14.tar.gz -C /tmp
-cd /tmp/check-0.9.14
-autoreconf -fi
-./configure ; make ; sudo make install
-
-cd $TRAVIS_BUILD_DIR
-sudo ldconfig

--- a/tests/check_baton.c
+++ b/tests/check_baton.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019 Genome
+ * Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020 Genome
  * Research Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -855,7 +855,6 @@ START_TEST(test_list_replicates_obj) {
 
     baton_error_t error;
     json_t *results = list_replicates(conn, &rods_path, &error);
-
     ck_assert_int_eq(error.code, 0);
     ck_assert(json_is_array(results));
 
@@ -922,7 +921,6 @@ START_TEST(test_list_timestamps_obj) {
 
     baton_error_t error;
     json_t *timestamps = list_timestamps(conn, &rods_path, &error);
-
     ck_assert_int_eq(error.code, 0);
     ck_assert(json_is_array(timestamps));
 

--- a/tests/scripts/setup_irods.sh
+++ b/tests/scripts/setup_irods.sh
@@ -48,26 +48,8 @@ then
     exit $status
 fi
 
-# Make replicates of test data
-ilsresc $test_resc >&/dev/null
-status=$?
-
-if [[ $status -ne 0 ]]
-then
-    echo "Test resource '$test_resc' is missing. Aborting"
-    exit $E_RESC_MISSING
-fi
-
-irepl -r -R $test_resc $out_path
-status=$?
-
-if [[ $status -ne 0 ]]
-then
-    echo "Failed to irepl test data to '$test_resc'"
-    exit $status
-else
-    echo "Replicated test data to '$test_resc'"
-fi
+# Make replicates of test data; use a replication resource instead of
+# doing this manually.
 
 # Ensure checksums are up to date
 ichksum -r -a -K $out_path >&/dev/null


### PR DESCRIPTION
Add iRODS 4.2.8 to the test matrix.

Check for both libirods_common and libirods_client for iRODS 4.2.x.

Use the available replication resource in the test server Docker image, rather than manually irepl to another local resource.

Use check library from Conda, rather than building from source.