### PR TITLE
Bugfix: double free for query input when listing inconsistent checksums

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 	[Upcoming]
 
+	Bugfix: double free for query input when listing checksums of a
+	dataobject that has inconsistent checksums.
+
 	[2.1.0]
 
 	Bugfix: Added a workaround for iRODS issue
@@ -11,8 +14,7 @@
 
 	Bugfix: exit non-zero when the iRODS plugins cannot be located.
 
-	Bugfix: fix segfault when operations require a path and none
-	supplied.
+	Bugfix: segfault when operations require a path and none supplied.
 
 	Add iRODS 4.2.8 to the test matrix.
 

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -15,7 +15,7 @@ conda config --set auto_update_conda False
 
 conda create -y -n travis
 conda activate travis
-conda install -y python
+conda install -y python=3.8
 pip install sphinx==2.4.0
 
 conda config --add channels https://dnap.cog.sanger.ac.uk/npg/conda/devel/generic/

--- a/src/list.c
+++ b/src/list.c
@@ -212,8 +212,6 @@ json_t *list_checksum(rcComm_t *conn, rodsPath_t *rods_path,
     results = do_query(conn, query_in, obj_format.labels, error);
     if (error->code != 0) goto error;
 
-    free_query_input(query_in);
-
     if (json_array_size(results) != 1) {
         set_baton_error(error, -1, "Expected 1 data object result but found %d",
                         json_array_size(results));
@@ -223,6 +221,7 @@ json_t *list_checksum(rcComm_t *conn, rodsPath_t *rods_path,
     json_t *obj = json_array_get(results, 0);
     json_t *checksum = json_incref(json_object_get(obj, JSON_CHECKSUM_KEY));
 
+    free_query_input(query_in);
     if (results) json_decref(results);
 
     return checksum;


### PR DESCRIPTION
Move the free_query_input call so that it is not called twice when an
error is raised listing checksums. This is triggered when checksums
have different values (including null) across the replicates of a
single data object.