### PR TITLE
Add verify on put support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,20 @@
 	[Upcoming]
 
+
+	Add a --verify flag to baton-put and "verify" to baton-do "put"
+	operations. This validates the uploaded file against a checksum
+	provided by the client. The client should provide a default
+	checksum algorithm, otherwise it will fall back to iRODS' default.
+	The checksum and verify options are mutually exclusive.
+
+	No longer force checksum re-caculation in baton_json_checksum_op.
+
+	Change signature of put_data_obj to add iRODS default resource.
+
+	Change option_flags enum order.
+
+	Change return type of checksum_data_obj.
+
 	Bugfix: double free for query input when listing checksums of a
 	dataobject that has inconsistent checksums.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,7 +8,7 @@ Welcome to ``baton``'s documentation
 ====================================
 
 baton \|bəˈtän|
-	*noun, A short stick or staff or something resembling one.*
+   *noun, A short stick or staff or something resembling one.*
 
 Client programs and API for use with `iRODS <http://www.irods.org>`_
 (Integrated Rule-Oriented Data System).
@@ -116,7 +116,7 @@ stream of JSON objects on standard output i.e.
 
 .. code-block:: sh
 
-   { object 1 }  { object 2 }  ...  { object n } 
+   { object 1 }  { object 2 }  ...  { object n }
 
 
 The JSON stream may be in a single file (the filename given on the
@@ -392,6 +392,13 @@ Options
    minutes.
 
 .. program:: baton-put
+.. option:: --checksum
+
+   Calculate and register, but don't verify, a checksum on the server
+   side (like the ``-k`` option of ``iput``). This option is
+   incompatible with ``--verify``
+
+.. program:: baton-put
 .. option:: --file <file name>
 
   A JSON file describing the data objects and collections. Optional,
@@ -421,6 +428,13 @@ Options
 .. option:: --verbose
 
   Print verbose messages to STDERR.
+
+.. program:: baton-put
+.. option:: --verify
+
+  Calculate and register a server-side checksum and verify the
+  uploaded data object against a client-side calculated checksum (like
+  the ``-K`` option of ``iput``).
 
 .. program:: baton-put
 .. option:: --version
@@ -793,7 +807,7 @@ Options
    Do not report iRODS errors by exiting with a non-zero error code. In
    this mode errors are reported only in-band of the JSON messages
    written to STDOUT.
-            
+
 .. program:: baton-do
 .. option:: --unbuffered
 

--- a/src/baton-put.c
+++ b/src/baton-put.c
@@ -1,5 +1,6 @@
 /**
- * Copyright (C) 2017, 2019 Genome Research Ltd. All rights reserved.
+ * Copyright (C) 2017, 2019, 2021 Genome Research Ltd. All rights
+ * reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,6 +28,7 @@
 #include "baton.h"
 
 static int checksum_flag      = 0;
+static int verify_flag        = 0;
 static int debug_flag         = 0;
 static int help_flag          = 0;
 static int silent_flag        = 0;
@@ -60,17 +62,18 @@ int main(int argc, char *argv[]) {
             {"unbuffered",    no_argument, &unbuffered_flag,    1},
             {"unsafe",        no_argument, &unsafe_flag,        1},
             {"verbose",       no_argument, &verbose_flag,       1},
+            {"verify",        no_argument, &verify_flag,        1},
             {"version",       no_argument, &version_flag,       1},
             {"wlock",         no_argument, &wlock_flag,         1},
             // Indexed options
-            {"connect-time", required_argument, NULL, 'c'},
+            {"connect-time",  required_argument, NULL, 'c'},
             {"buffer-size",   required_argument, NULL, 'b'},
             {"file",          required_argument, NULL, 'f'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        int c = getopt_long_only(argc, argv, "b:f:",
+        int c = getopt_long_only(argc, argv, "c:b:f:",
                                  long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -112,6 +115,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (checksum_flag)      flags = flags | CALCULATE_CHECKSUM;
+    if (verify_flag)        flags = flags | VERIFY_CHECKSUM;
     if (single_server_flag) flags = flags | SINGLE_SERVER;
     if (unsafe_flag)        flags = flags | UNSAFE_RESOLVE;
     if (unbuffered_flag)    flags = flags | FLUSH;
@@ -122,8 +126,9 @@ int main(int argc, char *argv[]) {
         "\n"
         "Synopsis\n"
         "\n"
-        "    baton-put [--connect-time <n>] [--file <JSON file>] [--silent]\n"
-        "              [--unbuffered] [--unsafe]\n"
+        "    baton-put [--checksum|--verify] [--connect-time <n>]\n"
+        "              [--file <JSON file>]\n"
+        "              [--silent] [--unbuffered] [--unsafe]\n"
         "              [--verbose] [--version] [--wlock]\n"
         "\n"
         "Description\n"
@@ -131,7 +136,8 @@ int main(int argc, char *argv[]) {
         "  JSON input file.\n"
         ""
         "  --buffer-size   Set the transfer buffer size.\n"
-        "  --checksum      Calculate a checksum on the server side.\n"
+        "  --checksum      Calculate and register a checksum on the server\n"
+        "                  side.\n"
         "  --connect-time  The duration in seconds after which a connection\n"
         "                  to iRODS will be refreshed (closed and reopened\n"
         "                  between JSON documents) to allow iRODS server\n"
@@ -144,6 +150,9 @@ int main(int argc, char *argv[]) {
         "  --unbuffered    Flush print operations for each JSON object.\n"
         "  --unsafe        Permit unsafe relative iRODS paths.\n"
         "  --verbose       Print verbose messages to STDERR.\n"
+        "  --verify        Calculate and register a checksum on the server\n"
+        "                  side and verify against a locally-calculated\n"
+        "                  checksum\n"
         "  --version       Print the version number and exit.\n"
         "  --wlock         Enable server-side advisory write locking.\n"
         "                  Optional, defaults to false.\n";

--- a/src/json.h
+++ b/src/json.h
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2017, 2019 Genome Research Ltd. All
- * rights reserved.
+ * Copyright (C) 2013, 2014, 2015, 2017, 2019, 2021 Genome Research
+ * Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -119,6 +119,7 @@
 #define JSON_OP_ACL                "acl"
 #define JSON_OP_AVU                "avu"
 #define JSON_OP_CHECKSUM           "checksum"
+#define JSON_OP_VERIFY             "verify"
 #define JSON_OP_FORCE              "force"
 #define JSON_OP_COLLECTION         "collection"
 #define JSON_OP_CONTENTS           "contents"
@@ -207,6 +208,8 @@ const char *get_created_timestamp(json_t *object, baton_error_t *error);
 
 const char *get_modified_timestamp(json_t *object, baton_error_t *error);
 
+const char *get_checksum(json_t *object, baton_error_t *error);
+
 const char* get_replicate_num(json_t *object, baton_error_t *error);
 
 const char *get_avu_attribute(json_t *avu, baton_error_t *error);
@@ -263,6 +266,8 @@ int op_avu_p(json_t *operation_args);
 
 int op_checksum_p(json_t *operation_args);
 
+int op_verify_p(json_t *operation_args);
+
 int op_force_p(json_t *operation_args);
 
 int op_collection_p(json_t *operation_args);
@@ -286,6 +291,8 @@ int op_single_server_p(json_t *operation_args);
 int op_size_p(json_t *operation_args);
 
 int op_timestamp_p(json_t *operation_args);
+
+int has_checksum(json_t *object);
 
 int has_collection(json_t *object);
 
@@ -344,12 +351,16 @@ json_t *make_replicate(const char *resource, const char *location,
                        const char *checksum, const char *replicate,
                        const char *status, baton_error_t *error);
 
+json_t *checksum_to_json(char *checksum, baton_error_t *error);
+
 json_t *data_object_parts_to_json(const char *coll_name, const char *data_name,
                                   baton_error_t *error);
 
 json_t *data_object_path_to_json(const char *path, baton_error_t *error);
 
 json_t *collection_path_to_json(const char *path, baton_error_t *error);
+
+char *json_to_checksum(json_t *object, baton_error_t *error);
 
 char *json_to_path(json_t *object, baton_error_t *error);
 

--- a/src/list.c
+++ b/src/list.c
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2016, 2017, 2019 Genome Research
- * Ltd. All rights reserved.
+ * Copyright (C) 2013, 2014, 2015, 2016, 2017, 2019, 2021 Genome
+ * Research Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -55,7 +55,9 @@ static json_t *list_data_object(rcComm_t *conn, rodsPath_t *rods_path,
     if (error->code != 0) goto error;
 
     if (json_array_size(results) != 1) {
-        set_baton_error(error, -1, "Expected 1 data object result but found %d",
+        set_baton_error(error, -1, "Expected 1 data object result but "
+                        "found %d. This occurs when the object replicates "
+                        "have different sizes in the iRODS database.",
                         json_array_size(results));
         goto error;
     }
@@ -115,7 +117,8 @@ static json_t *list_collection(rcComm_t *conn, rodsPath_t *rods_path,
                 logmsg(TRACE, "Identified '%s/%s' as a data object",
                        coll_entry.collName, coll_entry.dataName);
                 entry = data_object_parts_to_json(coll_entry.collName,
-                                                  coll_entry.dataName, error);
+                                                  coll_entry.dataName,
+                                                  error);
                 if (error->code != 0) goto query_error;
 
                 if (flags & PRINT_SIZE) {
@@ -213,7 +216,9 @@ json_t *list_checksum(rcComm_t *conn, rodsPath_t *rods_path,
     if (error->code != 0) goto error;
 
     if (json_array_size(results) != 1) {
-        set_baton_error(error, -1, "Expected 1 data object result but found %d",
+        set_baton_error(error, -1, "Expected 1 data object result but "
+                        "found %d. This occurs when the object replicates "
+                        "have different checksum values in the iRODS database",
                         json_array_size(results));
         goto error;
     }

--- a/src/operations.h
+++ b/src/operations.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019 Genome
+ * Copyright (C) 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2021 Genome
  * Research Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -73,22 +73,24 @@ typedef enum {
     PRINT_CHECKSUM     = 1 << 11,
     /** Calculate checksums for data objects */
     CALCULATE_CHECKSUM = 1 << 12,
+    /** Verify checksums for data objects */
+    VERIFY_CHECKSUM    = 1 << 13,
     /** Add an AVU */
-    ADD_AVU            = 1 << 13,
+    ADD_AVU            = 1 << 14,
     /** Remove an AVU */
-    REMOVE_AVU         = 1 << 14,
+    REMOVE_AVU         = 1 << 15,
     /** Recursive operation on collections */
-    RECURSIVE          = 1 << 15,
+    RECURSIVE          = 1 << 16,
     /** Save files */
-    SAVE_FILES         = 1 << 16,
+    SAVE_FILES         = 1 << 17,
     /** Flush output */
-    FLUSH              = 1 << 17,
+    FLUSH              = 1 << 18,
     /** Force an operation */
-    FORCE              = 1 << 18,
+    FORCE              = 1 << 19,
     /** Avoid any operations that contact servers other than rodshost */
-    SINGLE_SERVER      = 1 << 19,
+    SINGLE_SERVER      = 1 << 20,
     /** Use advisory write lock on server */
-    WRITE_LOCK         = 1 << 20
+    WRITE_LOCK         = 1 << 21
 } option_flags;
 
 typedef struct operation_args {

--- a/src/read.h
+++ b/src/read.h
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2014, 2015, 2016, 2017, 2018 Genome Research Ltd. All
- * rights reserved.
+ * Copyright (C) 2014, 2015, 2016, 2017, 2018, 2021 Genome Research
+ * Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -46,6 +46,12 @@ typedef struct data_obj_file {
 
 /**
  * Open a data object for reading or writing.
+ *
+ * This function calls rcDataobjCreate when creating a new data
+ * object. Both rcDataobjCreate (and rcDataObjWrite) have an optional
+ * parameter for setting the target resource, but none for setting a
+ * default resource, unlike rcDataObjPut. If that parameter were
+ * available, it would be added to this function.
  *
  * @param[in]  conn       An open iRODS connection.
  * @param[in]  rods_path  An iRODS data object path.
@@ -117,8 +123,8 @@ int get_data_obj_file(rcComm_t *conn, rodsPath_t *rods_path,
 int get_data_obj_stream(rcComm_t *conn, rodsPath_t *rods_path, FILE *out,
                         size_t buffer_size, baton_error_t *error);
 
-json_t *checksum_data_obj(rcComm_t *conn, rodsPath_t *rods_path,
-                          option_flags flags, baton_error_t *error);
+char *checksum_data_obj(rcComm_t *conn, rodsPath_t *rods_path,
+                        option_flags flags, baton_error_t *error);
 
 void set_md5_last_read(data_obj_file_t *obj_file, unsigned char digest[16]);
 

--- a/src/write.c
+++ b/src/write.c
@@ -105,7 +105,7 @@ int put_data_obj(rcComm_t *conn, const char *local_path, rodsPath_t *rods_path,
         addKeyVal(&obj_open_in.condInput, DEF_RESC_NAME_KW, default_resource);
     }
 
-    // Always force put over any existing data in order to amke puts
+    // Always force put over any existing data in order to make puts
     // idempotent.
     addKeyVal(&obj_open_in.condInput, FORCE_FLAG_KW, "");
 

--- a/src/write.h
+++ b/src/write.h
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2014, 2015, 2016, 2017, 2018 Genome Research Ltd. All
- * rights reserved.
+ * Copyright (C) 2014, 2015, 2016, 2017, 2018, 2021 Genome Research
+ * Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,18 +30,27 @@
 /**
  * Write to a data object from a local file using the put protocol.
  *
- * @param[in]  conn        An open iRODS connection.
- * @param[in]  obj_file    A local file name.
- * @param[in]  rods_path   An iRODS data object path.
- * @param[in]  flags       CALCULATE_CHECKSUM to calculate a checksum on
-                           the server side. WRITE_LOCK to use an advisory
-                           lock server-side. Optional.
- * @param[out] error       An error report struct.
+ * @param[in]  conn             An open iRODS connection.
+ * @param[in]  local_path       A local file path.
+ * @param[in]  rods_path        An iRODS data object path.
+ * @param[in]  default_resource An iRODS resource name. Optional, may be NULL.
+ * @param[in]  checksum         A checksum against which to verify the data
+ *                              on the server side. Optional, if not provided
+ *                              a checksum will be calculated on the client
+ *                              side.
+ * @param[in]  flags            CALCULATE_CHECKSUM to calculate and register a
+ *                              checksum on the server side, VERIFY_CHECKSUM to
+ *                              calculate and register a checksum on the server
+ *                              side and verify against a client side checksum,
+ *                              WRITE_LOCK to use an advisory lock on the
+ *                              server side. Optional.
+ * @param[out] error            An error report struct.
  *
  * @return The number of bytes copied in total.
  */
 int put_data_obj(rcComm_t *conn, const char *local_path, rodsPath_t *rods_path,
-                 int flags, baton_error_t *error);
+                 char *default_resource, char *checksum, int flags,
+		 baton_error_t *error);
 
 /**
  * Write bytes from a buffer into a data object.


### PR DESCRIPTION
Add a --verify flag to baton-put and "verify" to baton-do "put"
operations. This validates the uploaded file against a checksum
provided by the client. The client should provide a default
checksum algorithm, otherwise it will fall back to iRODS' default.
The checksum and verify options are mutually exclusive.

No longer force checksum re-caculation in baton_json_checksum_op.

Change signature of put_data_obj to add iRODS default resource.

Change option_flags enum order.

Change return type of checksum_data_obj.

Update documentation.