### PR TITLE
Explicitly free JSON checksums only on error

### DIFF
--- a/src/operations.c
+++ b/src/operations.c
@@ -426,7 +426,11 @@ json_t *baton_json_checksum_op(rodsEnv *env, rcComm_t *conn, json_t *target,
     if (error->code != 0) goto finally;
 
     add_checksum(target, jchecksum, error);
-    if (error->code != 0) goto finally;
+    if (error->code != 0) {
+	// Only free this on error. On success, it becomes owned by target
+	json_decref(jchecksum);
+	goto finally;
+    }
 
     result = json_deep_copy(target);
     if (!result) {
@@ -437,7 +441,6 @@ json_t *baton_json_checksum_op(rodsEnv *env, rcComm_t *conn, json_t *target,
 finally:
     if (path) free(path);
     if (checksum) free(checksum);
-    if (jchecksum) json_decref(jchecksum);
     if (rods_path.rodsObjStat) free(rods_path.rodsObjStat);
 
     return result;


### PR DESCRIPTION
baton-do sometimes fails to print a document for the checksum
operation. Investigating this led to finding an error where
checksum JSON was overzealously freed. Fixing that also appeared to
fix the bug, but I'm not 100% sure it is the root cause.

The JSON checksum should be freed only if it was not possible to
transfer ownership to the target that was passed in.

Fixes #242 