### PR TITLE
Restore functioning tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -75,13 +75,14 @@ jobs:
               "irods_user_name": "irods",
               "irods_zone_name": "testZone",
               "irods_home": "/testZone/home/irods",
-              "irods_default_resource": "testResc"
+              "irods_default_resource": "replResc"
           }
           EOF
 
           echo "irods" | script -q -c "iinit" /dev/null
           ienv
           ils
+          ilsresc
 
       - name: "Build and test baton"
         run: |
@@ -92,10 +93,17 @@ jobs:
           
           CPPFLAGS="-I$CONDA_ENV/include -I$CONDA_ENV/include/irods"
           LDFLAGS="-L$CONDA_ENV/lib -L$CONDA_ENV/lib/irods/externals"
+          PKG_CONFIG_PATH="$CONDA_ENV/lib/pkgconfig"
           
           autoreconf -i
-          ./configure CPPFLAGS="$CPPFLAGS" LDFLAGS="$LDFLAGS"
+          ./configure CPPFLAGS="$CPPFLAGS" LDFLAGS="$LDFLAGS" PKG_CONFIG_PATH="$PKG_CONFIG_PATH"
 
           export LD_LIBRARY_PATH="$CONDA_ENV/lib"
 
+          make check
           make distcheck DISTCHECK_CONFIGURE_FLAGS="CPPFLAGS=\"$CPPFLAGS\" LDFLAGS=\"$LDFLAGS\""
+
+      - name: "Show test log"
+        if: ${{ failure() }}
+        run: |
+          find "$GITHUB_WORKSPACE" -name \*.log -exec cat {} \;

--- a/tests/check_baton.c
+++ b/tests/check_baton.c
@@ -2116,8 +2116,18 @@ START_TEST(test_put_data_obj) {
 		     "dummy_bad_checksum",
 		     flags | VERIFY_CHECKSUM,
 		     &bad_checksum_error);
-    ck_assert_int_eq(bad_checksum_error.code, USER_CHKSUM_MISMATCH);
-    ck_assert_int_eq(bad_checksum_status, USER_CHKSUM_MISMATCH);
+
+    // Work around iRODS bug
+    // https://github.com/irods/irods/issues/5400 in versions to 4.2.8
+    if (IRODS_VERSION_MAJOR == 4 &&
+	IRODS_VERSION_MINOR == 2 &&
+	IRODS_VERSION_PATCHLEVEL < 9) {
+	fprintf(stderr, "Skipping put_data_obj bad checksum test on iRODS %d.%d.%d",
+		IRODS_VERSION_MAJOR, IRODS_VERSION_MINOR, IRODS_VERSION_PATCHLEVEL);
+    } else {
+	ck_assert_int_eq(bad_checksum_error.code, USER_CHKSUM_MISMATCH);
+	ck_assert_int_eq(bad_checksum_status, USER_CHKSUM_MISMATCH);
+    }
 
     if (conn) rcDisconnect(conn);
 }


### PR DESCRIPTION
Skip the test that always fails on iRODS <4.2.9 due to an iRODS bug.

Default to replResc resource in the iRODS environment file.

Set PKG_CONFIG_PATH to allow configure to find libcheck.

Print test log on failure.