### PR TITLE
Add support for iRODS 4.2.9

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,14 +18,16 @@ jobs:
 
     strategy:
       matrix:
-        experimental: [false]
         include:
           - irods: "4.2.7"
             server_image: "wsinpg/ub-16.04-irods-4.2.7:latest"
             experimental: false
           - irods: "4.2.8"
             server_image: "wsinpg/ub-18.04-irods-4.2.8:latest"
-            experimental: true
+            experimental: false
+          - irods: "4.2.9"
+            experimental: false
+            server_image: "wsinpg/ub-18.04-irods-4.2.9:latest"
 
     services:
       irods:

--- a/README
+++ b/README
@@ -40,20 +40,16 @@ iRODS compatibility:
 
 - Compatible with iRODS 4.1.x and 4.2.x
 
-  Only iRODS 4.x is supported on the main branch. If you use iRODS
-  3.x, please refer to the "irods-3-lts" branch which will provide
-  continued support for iRODS 3.x users to recieve backported
-  bugfixes, but will not see new features. No releases will be created
-  from the irods-3-lts branch - you will need to build from source.
-
-- Not compatible with iRODS 4.0.1 and 4.0.2 (which lack required API
-  functions with C linkage).
-
+  baton version  Compatible iRODS versions
+    2.0.x          4.1.x - 4.2.7
+    2.1.x          4.1.x - 4.2.7
+    3.0.x          4.2.7 - 4.2.8
+    3.1.x          4.2.7 - 4.2.9
 
 Installation:
 
-1. Install iRODS 4.x and the baton dependencies (Jansson) as described
-   in their documentation.
+1. Install iRODS >=4.1 and the baton dependencies (Jansson) as
+   described in their documentation.
 
 2. If you have cloned the baton git repository, run autoconf to
    generate the configure script:

--- a/src/baton.c
+++ b/src/baton.c
@@ -403,14 +403,14 @@ json_t *search_metadata(rcComm_t *conn, json_t *query, char *zone_name,
               .columns     = { COL_COLL_NAME, COL_DATA_NAME, COL_DATA_SIZE },
               .labels      = { JSON_COLLECTION_KEY, JSON_DATA_OBJECT_KEY,
                                JSON_SIZE_KEY },
-              .latest      = 1 };
+              .good_repl   = 1 };
     }
     else {
         obj_format = &(query_format_in_t)
             { .num_columns = 2,
               .columns     = { COL_COLL_NAME, COL_DATA_NAME },
               .labels      = { JSON_COLLECTION_KEY, JSON_DATA_OBJECT_KEY },
-              .latest      = 0 };
+              .good_repl   = 0 };
     }
 
     init_baton_error(error);

--- a/src/json_query.c
+++ b/src/json_query.c
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2016, 2019 Genome Research Ltd. All
- * rights reserved.
+ * Copyright (C) 2013, 2014, 2015, 2016, 2019, 2021 Genome Research
+ * Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -293,9 +293,9 @@ json_t *do_search(rcComm_t *conn, char *zone_name, json_t *query,
     query_in = prepare_json_avu_search(query_in, avus, prepare_avu, error);
     if (error->code != 0) goto error;
 
-    // Report latest replicate only
-    if (format->latest) {
-        query_in = limit_to_newest_repl(query_in);
+    // Report good replicates only
+    if (format->good_repl) {
+        query_in = limit_to_good_repl(query_in);
     }
 
     // ACL is optional

--- a/src/list.c
+++ b/src/list.c
@@ -50,6 +50,7 @@ static json_t *list_data_object(rcComm_t *conn, rodsPath_t *rods_path,
     query_in = make_query_input(SEARCH_MAX_ROWS, obj_format->num_columns,
                                 obj_format->columns);
     query_in = prepare_obj_list(query_in, rods_path, NULL);
+    query_in = limit_to_good_repl(query_in);
 
     results = do_query(conn, query_in, obj_format->labels, error);
     if (error->code != 0) goto error;

--- a/src/query.c
+++ b/src/query.c
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015 Genome Research Ltd. All rights
- * reserved.
+ * Copyright (C) 2013, 2014, 2015, 2021 Genome Research Ltd. All
+ * rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -42,7 +42,7 @@
 void log_rods_errstack(log_level level, rError_t *error) {
     int len = error->len;
     for (int i = 0; i < len; i++) {
-	    rErrMsg_t *errmsg = error->errMsg[i];
+        rErrMsg_t *errmsg = error->errMsg[i];
         logmsg(level, "Level %d: %s", i, errmsg->msg);
     }
 }
@@ -113,7 +113,7 @@ void free_query_input(genQueryInp_t *query_in) {
         free(query_in->condInput.keyWord);
     }
 
-	if (query_in->condInput.value != NULL) {
+    if (query_in->condInput.value != NULL) {
         free(query_in->condInput.value);
     }
 
@@ -154,7 +154,7 @@ genQueryInp_t *add_query_conds(genQueryInp_t *query_in, size_t num_conds,
             snprintf(expr, expr_size, "%s %s", operator, value);
         } else {
             snprintf(expr, expr_size, "%s '%s'", operator, value);
-	}
+        }
 
         logmsg(DEBUG, "Made string %d of %d: op: %s value: %s, len %d, "
                "total len %d [%s]",
@@ -210,8 +210,6 @@ genQueryInp_t *prepare_obj_list(genQueryInp_t *query_in,
     else {
         add_query_conds(query_in, num_conds, (query_cond_t []) { cn, dn });
     }
-
-    limit_to_newest_repl(query_in);
 
     free(path1);
     free(path2);
@@ -364,7 +362,20 @@ genQueryInp_t *prepare_col_avu_search(genQueryInp_t *query_in,
 }
 
 genQueryInp_t *limit_to_newest_repl(genQueryInp_t *query_in) {
+    return limit_to_good_repl(query_in);
+}
+
+genQueryInp_t *limit_to_good_repl(genQueryInp_t *query_in) {
+    // See https://github.com/irods/irods/issues/5730
+    //
+    // The #define used in iRODS 4.2.8 and earlier has been replaced
+    // with an enum member with the same value.
+#if IRODS_VERSION_INTEGER <= (4*1000000 + 2*1000 + 8)
     int col_selector = NEWLY_CREATED_COPY;
+#else
+    int col_selector = GOOD_REPLICA;
+#endif
+
     int num_digits = (col_selector == 0) ? 1 : log10(col_selector) + 1;
 
     char buf[num_digits + 1];

--- a/src/query.h
+++ b/src/query.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2016 Genome Research Ltd. All
+ * Copyright (C) 2013, 2014, 2015, 2016, 2021 Genome Research Ltd. All
  * rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -58,13 +58,15 @@
 
 typedef struct query_format_in {
     /** Return data for the latest replicate only */
-    unsigned int latest;
+    unsigned int latest __attribute((deprecated("this flag is redundant")));
     /** The number of columns to return */
     unsigned num_columns;
     /** The ICAT columns to return */
     const int columns[MAX_NUM_COLUMNS];
     /** The labels to use for the returned column values */
     const char *labels[MAX_NUM_COLUMNS];
+    /** Return data for good replicates only */
+    unsigned int good_repl;
 } query_format_in_t;
 
 typedef struct query_cond {
@@ -252,6 +254,12 @@ void free_squery_input(specificQueryInp_t *squery_in);
 
 void free_specific_labels(query_format_in_t *format);
 
+__attribute__((deprecated("use limit_to_good_repl instead")))
 genQueryInp_t *limit_to_newest_repl(genQueryInp_t *query_in);
+
+genQueryInp_t *limit_to_good_repl(genQueryInp_t *query_in);
+
+genQueryInp_t *add_select_modifier(genQueryInp_t *query_in, int column,
+                                   int modifier);
 
 #endif // _BATON_QUERY_H

--- a/src/read.c
+++ b/src/read.c
@@ -521,7 +521,12 @@ char *checksum_data_obj(rcComm_t *conn, rodsPath_t *rods_path,
             goto error;
     }
 
-    if ((flags & VERIFY_CHECKSUM) && (flags & CALCULATE_CHECKSUM)) {
+    if (!(flags & VERIFY_CHECKSUM) && !(flags & CALCULATE_CHECKSUM)) {
+	logmsg(DEBUG, "No checksum operation specified for '%s', defaulting "
+	       "to calculating a checksum",  rods_path->outPath);
+	flags = flags | CALCULATE_CHECKSUM;
+    }
+    else if ((flags & VERIFY_CHECKSUM) && (flags & CALCULATE_CHECKSUM)) {
         set_baton_error(error, USER_INPUT_OPTION_ERR,
                         "Cannot both verify and update the checksum "
                         "of data object '%s' ", rods_path->outPath);

--- a/src/write.c
+++ b/src/write.c
@@ -19,7 +19,14 @@
  * @author Keith James <kdj@sanger.ac.uk>
  */
 
-#include <checksum.hpp>
+// Workaround for the accidental removal of client-side checksum API
+// from iRODS in iRODS 4.1.x https://github.com/irods/irods/issues/5731
+
+#if IRODS_VERSION_INTEGER <= (4*1000000 + 2*1000 + 9)
+int chksumLocFile( const char *fileName, char *chksumStr, const char* );
+#else
+#include <checksum.h>
+#endif
 
 #include "config.h"
 #include "compat_checksum.h"
@@ -64,7 +71,7 @@ int put_data_obj(rcComm_t *conn, const char *local_path, rodsPath_t *rods_path,
 	    logmsg(DEBUG, "Using supplied local checksum '%s' for '%s'",
 		   chksum, rods_path->outPath);
 	}
-	else {	
+	else {
 	    // The hash scheme must be defined for rcChksumLocFile, but if
 	    // it is zero length, rcChksumLocFile falls back to the value
 	    // in the client environment. There's no advantage in our

--- a/tests/check_baton.c
+++ b/tests/check_baton.c
@@ -2072,8 +2072,8 @@ START_TEST(test_put_data_obj) {
     baton_error_t put_error;
     int put_status =
         put_data_obj(conn, file_path, &rods_obj_path, TEST_RESOURCE, md5,
-		     flags | VERIFY_CHECKSUM,
-		     &put_error);
+                     flags | VERIFY_CHECKSUM,
+                     &put_error);
     ck_assert_int_eq(put_error.code, 0);
     ck_assert_int_eq(put_status, 0);
 
@@ -2113,20 +2113,20 @@ START_TEST(test_put_data_obj) {
     baton_error_t bad_checksum_error;
     int bad_checksum_status =
         put_data_obj(conn, file_path, &rods_obj_path, TEST_RESOURCE,
-		     "dummy_bad_checksum",
-		     flags | VERIFY_CHECKSUM,
-		     &bad_checksum_error);
+                     "dummy_bad_checksum",
+                     flags | VERIFY_CHECKSUM,
+                     &bad_checksum_error);
 
     // Work around iRODS bug
     // https://github.com/irods/irods/issues/5400 in versions to 4.2.8
     if (IRODS_VERSION_MAJOR == 4 &&
-	IRODS_VERSION_MINOR == 2 &&
-	IRODS_VERSION_PATCHLEVEL < 9) {
-	fprintf(stderr, "Skipping put_data_obj bad checksum test on iRODS %d.%d.%d",
-		IRODS_VERSION_MAJOR, IRODS_VERSION_MINOR, IRODS_VERSION_PATCHLEVEL);
+        IRODS_VERSION_MINOR == 2 &&
+        IRODS_VERSION_PATCHLEVEL < 9) {
+        fprintf(stderr, "Skipping put_data_obj bad checksum test on iRODS %d.%d.%d",
+                IRODS_VERSION_MAJOR, IRODS_VERSION_MINOR, IRODS_VERSION_PATCHLEVEL);
     } else {
-	ck_assert_int_eq(bad_checksum_error.code, USER_CHKSUM_MISMATCH);
-	ck_assert_int_eq(bad_checksum_status, USER_CHKSUM_MISMATCH);
+        ck_assert_int_eq(bad_checksum_error.code, USER_CHKSUM_MISMATCH);
+        ck_assert_int_eq(bad_checksum_status, USER_CHKSUM_MISMATCH);
     }
 
     if (conn) rcDisconnect(conn);
@@ -2148,7 +2148,7 @@ START_TEST(test_checksum_data_obj) {
 
     char obj_path[MAX_PATH_LEN];
     snprintf(obj_path, MAX_PATH_LEN, "%s/test_checksum_data_obj.txt",
-	     rods_root);
+             rods_root);
 
     rodsPath_t rods_obj_path;
     baton_error_t resolve_error;
@@ -2158,7 +2158,7 @@ START_TEST(test_checksum_data_obj) {
 
     baton_error_t put_error;
     int put_status = put_data_obj(conn, file_path, &rods_obj_path,
-				  TEST_RESOURCE, NULL, flags, &put_error);
+                                  TEST_RESOURCE, NULL, flags, &put_error);
     ck_assert_int_eq(put_error.code, 0);
     ck_assert_int_eq(put_status, 0);
 
@@ -2170,7 +2170,7 @@ START_TEST(test_checksum_data_obj) {
 
     baton_error_t list_error;
     json_t *result = list_path(conn, &result_obj_path, PRINT_CHECKSUM,
-			       &list_error);
+                               &list_error);
     ck_assert_int_eq(list_error.code, 0);
     json_t *checksum = json_object_get(result, JSON_CHECKSUM_KEY);
 
@@ -2179,12 +2179,13 @@ START_TEST(test_checksum_data_obj) {
 
     baton_error_t flag_conflict_error;
     checksum_data_obj(conn, &result_obj_path,
-		      flags | CALCULATE_CHECKSUM | VERIFY_CHECKSUM,
-		      &flag_conflict_error);
+                      flags | CALCULATE_CHECKSUM | VERIFY_CHECKSUM,
+                      &flag_conflict_error);
     ck_assert_int_ne(flag_conflict_error.code, 0);
 
     baton_error_t checksum_error;
-    checksum_data_obj(conn, &result_obj_path, flags, &checksum_error);
+    checksum_data_obj(conn, &result_obj_path, flags | CALCULATE_CHECKSUM,
+                      &checksum_error);
     ck_assert_int_eq(checksum_error.code, 0);
 
     result = list_path(conn, &result_obj_path, PRINT_CHECKSUM, &list_error);
@@ -2194,7 +2195,7 @@ START_TEST(test_checksum_data_obj) {
     ck_assert(json_is_string(checksum));
     ck_assert_str_eq(json_string_value(checksum),
                      "4efe0c1befd6f6ac4621cbdb13241246");
-    json_decref(result);    
+    json_decref(result);
 }
 END_TEST
 
@@ -2403,7 +2404,7 @@ START_TEST(test_irods_get_sql_for_specific_alias_with_alias) {
 
     ck_assert_ptr_ne(sql, NULL);
     ck_assert_str_eq(sql,
-		     "SELECT DISTINCT Data.data_id AS data_id FROM R_DATA_MAIN Data WHERE CAST(Data.modify_ts AS INT) > CAST(? AS INT) AND CAST(Data.modify_ts AS INT) <= CAST(? AS INT)");
+                     "SELECT DISTINCT Data.data_id AS data_id FROM R_DATA_MAIN Data WHERE CAST(Data.modify_ts AS INT) > CAST(? AS INT) AND CAST(Data.modify_ts AS INT) <= CAST(? AS INT)");
 
     if (conn) rcDisconnect(conn);
 }
@@ -2698,8 +2699,8 @@ START_TEST(test_regression_github_issue242) {
                                        flags, &resolve_error), EXIST_ST);
 
     json_t *target = json_pack("{s:s, s:s}",
-			       JSON_COLLECTION_KEY,  rods_root,
-			       JSON_DATA_OBJECT_KEY, "f1.txt.no_checksum");
+                               JSON_COLLECTION_KEY,  rods_root,
+                               JSON_DATA_OBJECT_KEY, "f1.txt.no_checksum");
     operation_args_t args = { .flags            = 0,
                               .buffer_size      =  1024 * 64 * 16 * 2,
                               .zone_name        = "testZone",
@@ -2711,7 +2712,7 @@ START_TEST(test_regression_github_issue242) {
     ck_assert(json_is_object(result));
     ck_assert(json_object_get(result, JSON_CHECKSUM_KEY));
     ck_assert(json_equal(json_object_get(result, JSON_CHECKSUM_KEY),
-			 json_string("d41d8cd98f00b204e9800998ecf8427e")));
+                         json_string("d41d8cd98f00b204e9800998ecf8427e")));
 }
 
 Suite *baton_suite(void) {

--- a/tests/scripts/setup_irods.sh
+++ b/tests/scripts/setup_irods.sh
@@ -52,7 +52,7 @@ fi
 # doing this manually.
 
 # Ensure checksums are up to date
-ichksum -r -a -K $out_path >&/dev/null
+ichksum -r -a -f $out_path >&/dev/null
 status=$?
 
 if [[ $status -ne 0 ]]


### PR DESCRIPTION
iRODS 4.2.9 makes some API changes which are accommodated here, while
retaining backward compatibility with previous 4.x versions.

The most significant change is the addition of the ability to select
"good" replicates i.e. at-rest on the server. Previously we were able
only to select "newly created" replicates i.e. those which were not
stale, but which could be in-flight. This change in iRODS was made
possible by adding object locking to the server.

The API features for the old-style "newly created" replicates are
marked as deprecated and redirect to API for "good" replicates on
iRODS >= 4.2.9.

Add default of creating checksums to checksum_data_obj if no operation
is specified.

Add -f option to ichksum for creating test data so that checksums get
created. This is a change to ichksum behaviour in 4.2.9.