### PR TITLE
Exit when the file provided by the -f option can't be opened

### DIFF
--- a/src/baton-chmod.c
+++ b/src/baton-chmod.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2014, 2015, 2017, 2019 Genome Research Ltd. All
+ * Copyright (C) 2014, 2015, 2017, 2019, 2021 Genome Research Ltd. All
  * rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -146,6 +146,9 @@ int main(int argc, char *argv[]) {
 
     declare_client_name(argv[0]);
     input = maybe_stdin(json_file);
+    if (!input) {
+        exit(1);
+    }
 
     operation_args_t args = { .flags            = flags,
                               .max_connect_time = max_connect_time};

--- a/src/baton-do.c
+++ b/src/baton-do.c
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2017, 2018, 2019 Genome Research Ltd. All rights
- * reserved.
+ * Copyright (C) 2017, 2018, 2019, 2021 Genome Research Ltd. All
+ * rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -164,6 +164,9 @@ int main(int argc, char *argv[]) {
 
     declare_client_name(argv[0]);
     input = maybe_stdin(json_file);
+    if (!input) {
+        exit(1);
+    }
 
     operation_args_t args = { .flags            = flags,
                               .buffer_size      = default_buffer_size,

--- a/src/baton-get.c
+++ b/src/baton-get.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2014, 2015, 2017, 2019 Genome Research Ltd. All
+ * Copyright (C) 2014, 2015, 2017, 2019, 2021 Genome Research Ltd. All
  * rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -187,6 +187,9 @@ int main(int argc, char *argv[]) {
 
     declare_client_name(argv[0]);
     input = maybe_stdin(json_file);
+    if (!input) {
+        exit(1);
+    }
 
     if (buffer_size > max_buffer_size) {
         logmsg(WARN, "Requested transfer buffer size %zu exceeds maximum of "

--- a/src/baton-list.c
+++ b/src/baton-list.c
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2017, 2019 Genome Research Ltd. All
- * rights reserved.
+ * Copyright (C) 2013, 2014, 2015, 2017, 2019, 2021 Genome Research
+ * Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -173,6 +173,9 @@ int main(int argc, char *argv[]) {
 
     declare_client_name(argv[0]);
     input = maybe_stdin(json_file);
+    if (!input) {
+        exit(1);
+    }
 
     operation_args_t args = { .flags            = flags,
                               .max_connect_time = max_connect_time };

--- a/src/baton-metamod.c
+++ b/src/baton-metamod.c
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2017, 2019 Genome Research Ltd. All
- * rights reserved.
+ * Copyright (C) 2013, 2014, 2015, 2017, 2019, 2021 Genome Research
+ * Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -157,6 +157,9 @@ int main(int argc, char *argv[]) {
 
     declare_client_name(argv[0]);
     input = maybe_stdin(json_file);
+    if (!input) {
+        exit(1);
+    }
 
     operation_args_t args = { .flags            = flags,
                               .max_connect_time = max_connect_time };

--- a/src/baton-metaquery.c
+++ b/src/baton-metaquery.c
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2017, 2019 Genome Research Ltd. All
- * rights reserved.
+ * Copyright (C) 2013, 2014, 2015, 2017, 2019, 2021 Genome Research
+ * Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -188,6 +188,9 @@ int main(int argc, char *argv[]) {
 
     declare_client_name(argv[0]);
     input = maybe_stdin(json_file);
+    if (!input) {
+        exit(1);
+    }
 
     operation_args_t args = { .flags            = flags,
                               .zone_name        = zone_name,

--- a/src/baton-metasuper.c
+++ b/src/baton-metasuper.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2017 Genome Research Ltd. All
+ * Copyright (C) 2013, 2014, 2015, 2017, 2021 Genome Research Ltd. All
  * rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -118,6 +118,10 @@ int main(int argc, char *argv[]) {
 
     declare_client_name(argv[0]);
     input = maybe_stdin(json_file);
+    if (!input) {
+        exit(1);
+    }
+
     int status = do_supersede_metadata(input, oflags);
 
     if (status != 0) exit_status = 5;

--- a/src/baton-put.c
+++ b/src/baton-put.c
@@ -175,6 +175,9 @@ int main(int argc, char *argv[]) {
 
     declare_client_name(argv[0]);
     input = maybe_stdin(json_file);
+    if (!input) {
+        exit(1);
+    }
 
     operation_args_t args = { .flags            = flags,
                               .buffer_size      = default_buffer_size,

--- a/src/baton-specificquery.c
+++ b/src/baton-specificquery.c
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2013, 2014, 2015, 2016, 2017 Genome Research Ltd. All
- * rights reserved.
+ * Copyright (c) 2013, 2014, 2015, 2016, 2017, 2021 Genome Research
+ * Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -118,6 +118,10 @@ int main(int argc, char *argv[]) {
 
     declare_client_name(argv[0]);
     input = maybe_stdin(json_file);
+    if (!input) {
+        exit(1);
+    }
+
     int status = do_search_specific(input, zone_name);
     if (status != 0) exit_status = 5;
 


### PR DESCRIPTION
All the CLI programs would segfault if the file specified by `-f | --file` doesn't exist, despite detecting the problem and printing an error message.