### PR TITLE
Set `num_read` to zero in `read_chunk` error block.

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -233,6 +233,7 @@ size_t read_chunk(rcComm_t *conn, data_obj_file_t *data_obj, char *buffer,
         set_baton_error(error, num_read,
                         "Failed to read up to %zu bytes from '%s': %s",
                         len, data_obj->path, err_name);
+        num_read = 0;
         goto finally;
     }
 

--- a/tests/scripts/teardown_irods.sh
+++ b/tests/scripts/teardown_irods.sh
@@ -6,14 +6,16 @@
 
 E_ARGS_MISSING=3
 
-in_path=$1
+owner="$1"
+in_path="$2"
 
-if [[ $# < 1 ]]
+if [[ $# < 2 ]]
 then
-    echo "Insufficient command line arguments; expected 1"
+    echo "Insufficient command line arguments; expected 2"
     exit $E_ARGS_MISSING
 fi
 
-irm -rf $in_path
+ichmod -r own "$owner" "$in_path"
+irm -rf "$in_path"
 
 exit


### PR DESCRIPTION
Negative values of iRODS errors were causing overflow when returned as
`size_t`, which caused `slurp_data_obj` to attempt to access a very
large chunk of memory, resulting in a segmentation fault.