### PR TITLE
Add minimal Docker setup to enable a build and test run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+FROM ubuntu:bionic
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends \
+    apt-utils \
+    ca-certificates \
+    curl \
+    gpg \
+    gpg-agent \
+    lsb-release \
+    locales && \
+    locale-gen en_GB en_GB.UTF-8 && \
+    localedef -i en_GB -c -f UTF-8 -A /usr/share/locale/locale.alias en_GB.UTF-8
+
+ENV LANG=en_GB.UTF-8 \
+    LANGUAGE=en_GB \
+    LC_ALL=en_GB.UTF-8
+
+ENV IRODS_VERSION=4.2.11-1~bionic
+
+RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" |\
+    tee /etc/apt/sources.list.d/renci-irods.list && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends \
+    irods-dev="$IRODS_VERSION" \
+    irods-runtime="$IRODS_VERSION" \
+    irods-icommands="$IRODS_VERSION"
+
+RUN apt-get update && \
+    apt-get install -q -y --no-install-recommends \
+    autoconf \
+    automake \
+    build-essential \
+    check \
+    gdb \
+    git \
+    jq \
+    lcov \
+    less \
+    libjansson-dev \
+    libtool \
+    pkg-config \
+    ssh \
+    valgrind \
+    unattended-upgrades && \
+    unattended-upgrade -d -v
+
+ARG USER=baton
+ARG UID=1000
+ARG GID=$UID
+
+RUN groupadd --gid $GID $USER && \
+    useradd --uid $UID --gid $GID --shell /bin/bash --create-home $USER
+
+USER $USER
+
+ENV CPPFLAGS="-I/usr/include/irods" \
+    CK_DEFAULT_TIMEOUT=20
+
+CMD ["/bin/bash"]

--- a/README
+++ b/README
@@ -96,6 +96,17 @@ Installation:
    make clean install
 
 
+Development:
+
+To set up a development environment in Docker, use the provided
+docker-compose.yml and corresponding Dockerfile. These create a Linux
+C development and testing environment with an accompanying iRODS server.
+The recommended way to use this is by remote development in the container
+using VSCode. VSCode's manual explains how to do this, see:
+
+    https://code.visualstudio.com/docs/remote/containers
+
+
 Synopsis:
 
 For full details of the JSON accepted and returned by the programs in

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  irods-server:
+    container_name: irods-server
+    image: "wsinpg/ub-18.04-irods-${IRODS_VERSION:-4.2.11}:${DOCKER_TAG:-latest}"
+    restart: always
+    ports:
+      - "1247:1247"
+      - "20000-20199:20000-20199"
+
+  baton:  
+    image: baton
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    volumes:
+      - "${PWD}:/code"
+    environment:
+      IRODS_ENVIRONMENT_FILE: "/code/tests/.irods/irods_environment.json"
+    depends_on:
+      - irods-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
 
   baton:  
     image: baton
+    platform: linux/amd64
     build:
       context: .
       dockerfile: ./Dockerfile

--- a/tests/.irods/irods_environment.json
+++ b/tests/.irods/irods_environment.json
@@ -1,0 +1,9 @@
+{
+    "irods_host": "irods-server",
+    "irods_port": 1247,
+    "irods_user_name": "irods",
+    "irods_zone_name": "testZone",
+    "irods_home": "/testZone/home/irods",
+    "irods_default_resource": "replResc",
+    "irods_default_hash_scheme": "MD5"
+}


### PR DESCRIPTION
This setup is sufficient to build and run tests inside a VScode container. There is one test which fails inside a Docker container because it invokes the docker client itself. Fixing that is tech debt