### PR TITLE
Add iRODS 4.3.1 Ubuntu 22.04 as a required test target

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,16 +26,11 @@ jobs:
             build_image: "ghcr.io/wtsi-npg/ub-18.04-irods-clients-dev-4.2.12:latest"
             server_image: "ghcr.io/wtsi-npg/ub-18.04-irods-4.2.12:latest"
             experimental: false
-          # iRODS 4.3.0 clients on Ubuntu 18.04
-          - irods: "4.3.0"
-            build_image: "ghcr.io/wtsi-npg/ub-18.04-irods-clients-dev-4.3.0:latest"
-            server_image: "ghcr.io/wtsi-npg/ub-18.04-irods-4.3.0:latest"
-            experimental: true
-          # iRODS 4.3.0 clients on Ubuntu 20.04
-          - irods: "4.3.0"
-            build_image: "ghcr.io/wtsi-npg/ub-20.04-irods-clients-dev-4.3.0:latest"
-            server_image: "ghcr.io/wtsi-npg/ub-18.04-irods-4.3.0:latest"
-            experimental: true
+          # iRODS 4.3.1 clients on Ubuntu 22.04
+          - irods: "4.3.1"
+            build_image: "ghcr.io/wtsi-npg/ub-22.04-irods-clients-dev-4.3.1:latest"
+            server_image: "ghcr.io/wtsi-npg/ub-22.04-irods-4.3.1:latest"
+            experimental: false
           # iRODS 4.3-nightly on Ubuntu 22.04
           - irods: "4.3-nightly"
             build_image: "ghcr.io/wtsi-npg/ub-22.04-irods-clients-dev-4.3-nightly:latest"


### PR DESCRIPTION
Remove iRODS 4.3.0 from tests