### PR TITLE
Fix for the Upload Action no longer working for older containers

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -ex
+
+git config --global --add safe.directory "$PWD"
+
+autoreconf -fi
+./configure
+make dist
+
+dist_file=$(find . -name baton-\*.tar.gz -print0)
+sha256sum "$dist_file" > "$dist_file".sha256
+
+ls -l

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -14,12 +14,9 @@ jobs:
       run:
         shell: bash -l -e -o pipefail {0}
 
-    container:
-      image: "ghcr.io/wtsi-npg/ub-18.04-irods-clients-dev-4.2.11:latest"
-
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -32,16 +29,10 @@ jobs:
           git fetch --tags --force
 
       - name: "Build Package"
-        run: |
-          # Avoid git exiting when Actions runs
-          git config --global --add safe.directory "$PWD"
-
-          autoreconf -fi
-          ./configure
-          make dist
-
-          dist_file=$(ls baton-*.tar.gz)
-          sha256sum "$dist_file" > "$dist_file".sha256
+        uses: wtsi-npg/build-irods-client-action@v1.0.0
+        with:
+          build-script:
+            ./.github/workflows/build.sh
 
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v4
@@ -60,7 +51,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Change to using a purpose-built GitHub Action to isolate the iRODS environment from the newer environments required by other parts of the CI workflow.