### PR TITLE
Fix the -dirty flag on the reported version when building with Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,1 @@
-.dockerignore
-.DS_Store
 .env
-.github
-.gitignore
-.vscode
-ChangeLog
-COPYING
-docker-compose.yml
-Dockerfile
-INSTALL
-README.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,15 @@
 *.l[oa]
 *.log
 *~
+.DS_Store
+.devcontainer
+.env
+.idea
+.vscode
 *.cache
 *.dSYM
 .deps
 .libs
-doc/_build
-tests/*.trs
 ar-lib
 compile
 config.*
@@ -25,6 +28,11 @@ GRTAGS
 GTAGS
 aclocal.m4
 configure
+ub-*-baton-irods-*
+Makefile
+doc/Makefile
+doc/_build
+doc/baton.1
 m4/libtool.m4
 m4/ltoptions.m4
 m4/ltsugar.m4
@@ -37,3 +45,5 @@ src/baton-metamod
 src/baton-metaquery
 src/baton-metasuper
 src/baton-specificquery
+tests/*.trs
+tests/Makefile

--- a/release/ubuntu/22.04/Dockerfile
+++ b/release/ubuntu/22.04/Dockerfile
@@ -32,10 +32,6 @@ RUN apt-get update && \
     irods-dev="${IRODS_VERSION}-0~$(lsb_release -sc)" \
     irods-runtime="${IRODS_VERSION}-0~$(lsb_release -sc)"
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "E1DD270288B4E6030699E45FA1715D88E1DF1F24" && \
-    echo "deb https://ppa.launchpadcontent.net/git-core/ppa/ubuntu $(lsb_release -sc) main" |\
-    tee /etc/apt/sources.list.d/git-core.list
-
 RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     autoconf \


### PR DESCRIPTION
Update .gitignore and .dockerignore to avoid the build being reported as dirty.

Remove the redundant git PPA apt repository from the list.