### PR TITLE
Fix baton-list and baton-do list operation not printing null checksums

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Compatible with iRODS 4.1.x, 4.2.x and 4.3.x
   | 3.1.x        | 4.2.7 - 4.2.9            |
   | 3.2.x        | 4.2.7 - 4.2.11           |
   | 3.3.x        | 4.2.7 - 4.2.11           |
-  | 4.2.x        | 4.2.7 - 4.3.1            |
+  | 4.2.x        | 4.2.7 - 4.3.3            |
 
 
 Note that building against iRODS 4.3.0 requires 
@@ -56,7 +56,7 @@ Note that building against iRODS 4.3.0 requires
     LDFLAGS="-Wl,-z,muldefs"
 
 due to https://github.com/irods/irods/issues/6448 (which is fixed
-in iRODS 4.3.1).
+in iRODS 4.3.1 and later).
 
 ## Installation:
 

--- a/src/baton-list.c
+++ b/src/baton-list.c
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2017, 2019, 2021 Genome Research
- * Ltd. All rights reserved.
+ * Copyright (C) 2013, 2014, 2015, 2017, 2019, 2021, 2024 Genome
+ * Research Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -134,25 +134,25 @@ int main(int argc, char *argv[]) {
         "    Lists data objects and collections described in a JSON\n"
         "    input file.\n"
         "\n"
-        "    --acl         Print access control lists in output.\n"
-        "    --avu         Print AVU lists in output.\n"
-        "    --checksum    Print data object checksums in output.\n"
-        "  --connect-time  The duration in seconds after which a connection\n"
-        "                  to iRODS will be refreshed (closed and reopened\n"
-        "                  between JSON documents) to allow iRODS server\n"
-        "                  resources to be released. Optional, defaults to\n"
-        "                  10 minutes.\n"
-        "    --contents    Print collection contents in output.\n"
-        "    --file        The JSON file describing the data objects and\n"
-        "                  collections. Optional, defaults to STDIN.\n"
-        "    --replicate   Print data object replicates.\n"
-        "    --silent      Silence warning messages.\n"
-        "    --size        Print data object sizes in output.\n"
-        "    --timestamp   Print timestamps in output.\n"
-        "    --unbuffered  Flush print operations for each JSON object.\n"
-        "    --unsafe      Permit unsafe relative iRODS paths.\n"
-        "    --verbose     Print verbose messages to STDERR.\n"
-        "    --version     Print the version number and exit.\n";
+        "    --acl           Print access control lists in output.\n"
+        "    --avu           Print AVU lists in output.\n"
+        "    --checksum      Print data object checksums in output.\n"
+        "    --connect-time  The duration in seconds after which a connection\n"
+        "                    to iRODS will be refreshed (closed and reopened\n"
+        "                    between JSON documents) to allow iRODS server\n"
+        "                    resources to be released. Optional, defaults to\n"
+        "                    10 minutes.\n"
+        "    --contents      Print collection contents in output.\n"
+        "    --file          The JSON file describing the data objects and\n"
+        "                    collections. Optional, defaults to STDIN.\n"
+        "    --replicate     Print data object replicates.\n"
+        "    --silent        Silence warning messages.\n"
+        "    --size          Print data object sizes in output.\n"
+        "    --timestamp     Print timestamps in output.\n"
+        "    --unbuffered    Flush print operations for each JSON object.\n"
+        "    --unsafe        Permit unsafe relative iRODS paths.\n"
+        "    --verbose       Print verbose messages to STDERR.\n"
+        "    --version       Print the version number and exit.\n";
 
     if (help_flag) {
         printf("%s\n",help);

--- a/src/json.c
+++ b/src/json.c
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2017, 2019, 2021 Genome Research
- * Ltd. All rights reserved.
+ * Copyright (C) 2013, 2014, 2015, 2017, 2019, 2021, 2024 Genome
+ * Research Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -609,12 +609,16 @@ int op_avu_p(json_t *operation_args) {
     return json_is_true(json_object_get(operation_args, JSON_OP_AVU));
 }
 
-int op_checksum_p(json_t *operation_args) {
-    return json_is_true(json_object_get(operation_args, JSON_OP_CHECKSUM));
+int op_print_checksum_p(json_t *operation_args) {
+    return json_is_true(json_object_get(operation_args, JSON_OP_PRINT_CHECKSUM));
 }
 
-int op_verify_p(json_t *operation_args) {
-    return json_is_true(json_object_get(operation_args, JSON_OP_VERIFY));
+int op_calculate_checksum_p(json_t *operation_args) {
+    return json_is_true(json_object_get(operation_args, JSON_OP_CALCULATE_CHECKSUM));
+}
+
+int op_verify_checksum_p(json_t *operation_args) {
+    return json_is_true(json_object_get(operation_args, JSON_OP_VERIFY_CHECKSUM));
 }
 
 int op_force_p(json_t *operation_args) {

--- a/src/json.h
+++ b/src/json.h
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2017, 2019, 2021 Genome Research
- * Ltd. All rights reserved.
+ * Copyright (C) 2013, 2014, 2015, 2017, 2019, 2021, 2024 Genome
+ * Research Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -118,8 +118,9 @@
 
 #define JSON_OP_ACL                "acl"
 #define JSON_OP_AVU                "avu"
-#define JSON_OP_CHECKSUM           "checksum"
-#define JSON_OP_VERIFY             "verify"
+#define JSON_OP_PRINT_CHECKSUM     "checksum"
+#define JSON_OP_CALCULATE_CHECKSUM "checksum"
+#define JSON_OP_VERIFY_CHECKSUM    "verify"
 #define JSON_OP_FORCE              "force"
 #define JSON_OP_COLLECTION         "collection"
 #define JSON_OP_CONTENTS           "contents"
@@ -264,9 +265,11 @@ int op_acl_p(json_t *operation_args);
 
 int op_avu_p(json_t *operation_args);
 
-int op_checksum_p(json_t *operation_args);
+int op_print_checksum_p(json_t *operation_args);
 
-int op_verify_p(json_t *operation_args);
+int op_calculate_checksum_p(json_t *operation_args);
+
+int op_verify_checksum_p(json_t *operation_args);
 
 int op_force_p(json_t *operation_args);
 

--- a/src/list.c
+++ b/src/list.c
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2013, 2014, 2015, 2016, 2017, 2019, 2021, 2023 Genome
- * Research Ltd. All rights reserved.
+ * Copyright (C) 2013, 2014, 2015, 2016, 2017, 2019, 2021, 2023,
+ * 2024 Genome Research Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -229,7 +229,14 @@ json_t *list_checksum(rcComm_t *conn, rodsPath_t *rods_path,
     }
 
     json_t *obj = json_array_get(results, 0);
-    json_t *checksum = json_incref(json_object_get(obj, JSON_CHECKSUM_KEY));
+    json_t *c = json_object_get(obj, JSON_CHECKSUM_KEY);
+    json_t *checksum;
+    if (c != NULL) {
+        checksum = json_incref(c);
+    }
+    else {
+        checksum = json_null();
+    }
 
     free_query_input(query_in);
     if (results) json_decref(results);

--- a/src/operations.c
+++ b/src/operations.c
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 Genome Research
- * Ltd. All rights reserved.
+ * Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 , 2024 Genome
+ * Research Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -250,25 +250,22 @@ json_t *baton_json_dispatch_op(rodsEnv *env, rcComm_t *conn, json_t *envelope,
         if (error->code != 0)  goto finally;
 
         option_flags flags = args_copy.flags;
-        if (op_acl_p(args))           flags = flags | PRINT_ACL;
-        if (op_avu_p(args))           flags = flags | PRINT_AVU;
-        if (op_checksum_p(args))      flags = flags |
-                                          CALCULATE_CHECKSUM |
-                                          PRINT_CHECKSUM;
-        if (op_verify_p(args))        flags = flags |
-                                          VERIFY_CHECKSUM |
-                                          PRINT_CHECKSUM;
-        if (op_contents_p(args))      flags = flags | PRINT_CONTENTS;
-        if (op_replicate_p(args))     flags = flags | PRINT_REPLICATE;
-        if (op_size_p(args))          flags = flags | PRINT_SIZE;
-        if (op_timestamp_p(args))     flags = flags | PRINT_TIMESTAMP;
-        if (op_raw_p(args))           flags = flags | PRINT_RAW;
-        if (op_save_p(args))          flags = flags | SAVE_FILES;
-        if (op_recurse_p(args))       flags = flags | RECURSIVE;
-        if (op_force_p(args))         flags = flags | FORCE;
-        if (op_collection_p(args))    flags = flags | SEARCH_COLLECTIONS;
-        if (op_object_p(args))        flags = flags | SEARCH_OBJECTS;
-        if (op_single_server_p(args)) flags = flags | SINGLE_SERVER;
+        if (op_acl_p(args))                 flags = flags | PRINT_ACL;
+        if (op_avu_p(args))                 flags = flags | PRINT_AVU;
+        if (op_print_checksum_p(args))      flags = flags | PRINT_CHECKSUM;
+        if (op_calculate_checksum_p(args))  flags = flags | CALCULATE_CHECKSUM | PRINT_CHECKSUM;
+        if (op_verify_checksum_p(args))     flags = flags | VERIFY_CHECKSUM    | PRINT_CHECKSUM;
+        if (op_contents_p(args))            flags = flags | PRINT_CONTENTS;
+        if (op_replicate_p(args))           flags = flags | PRINT_REPLICATE;
+        if (op_size_p(args))                flags = flags | PRINT_SIZE;
+        if (op_timestamp_p(args))           flags = flags | PRINT_TIMESTAMP;
+        if (op_raw_p(args))                 flags = flags | PRINT_RAW;
+        if (op_save_p(args))                flags = flags | SAVE_FILES;
+        if (op_recurse_p(args))             flags = flags | RECURSIVE;
+        if (op_force_p(args))               flags = flags | FORCE;
+        if (op_collection_p(args))          flags = flags | SEARCH_COLLECTIONS;
+        if (op_object_p(args))              flags = flags | SEARCH_OBJECTS;
+        if (op_single_server_p(args))       flags = flags | SINGLE_SERVER;
         args_copy.flags = flags;
 
         if (has_operation(args)) {
@@ -320,6 +317,12 @@ json_t *baton_json_dispatch_op(rodsEnv *env, rcComm_t *conn, json_t *envelope,
     }
     else if (str_equals(op, JSON_LIST_OP, MAX_STR_LEN)) {
         result = baton_json_list_op(env, conn, target, &args_copy, error);
+        if (error->code != 0) goto finally;
+
+        if (args_copy.flags & PRINT_CHECKSUM) {
+            result = add_checksum_json_object(conn, result, error);
+            if (error->code != 0) goto finally;
+        }
     }
     else if (str_equals(op, JSON_METAMOD_OP, MAX_STR_LEN)) {
         result = baton_json_metamod_op(env, conn, target, &args_copy, error);

--- a/tests/check_baton.c
+++ b/tests/check_baton.c
@@ -2211,7 +2211,7 @@ START_TEST(test_checksum_data_obj) {
     ck_assert_int_eq(list_error.code, 0);
     json_t *checksum = json_object_get(result, JSON_CHECKSUM_KEY);
 
-    ck_assert_ptr_eq(checksum, NULL);
+    ck_assert(json_is_null(checksum));
     json_decref(result);
 
     baton_error_t flag_conflict_error;


### PR DESCRIPTION
Due to an incorrect check for JSON null, the checkum attribute was omitted from output JSON, even when specifically requested. This change fixes that behaviour and also rationalises the naming of the checksum flags for the print, calculate and verify operations so that they are more explicit.