### PR TITLE
Fix invalid error message when listing checksums across a collection

### DIFF
--- a/src/operations.c
+++ b/src/operations.c
@@ -318,11 +318,6 @@ json_t *baton_json_dispatch_op(rodsEnv *env, rcComm_t *conn, json_t *envelope,
     else if (str_equals(op, JSON_LIST_OP, MAX_STR_LEN)) {
         result = baton_json_list_op(env, conn, target, &args_copy, error);
         if (error->code != 0) goto finally;
-
-        if (args_copy.flags & PRINT_CHECKSUM) {
-            result = add_checksum_json_object(conn, result, error);
-            if (error->code != 0) goto finally;
-        }
     }
     else if (str_equals(op, JSON_METAMOD_OP, MAX_STR_LEN)) {
         result = baton_json_metamod_op(env, conn, target, &args_copy, error);


### PR DESCRIPTION
Listing collection contents raised an invalid error if checksums were requested. Remove the lines causing this because they are simply an incorrect addition.