### PR TITLE
Fix initialisation of rodsPath_t

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,4 +1,3 @@
-
 name: "Create release"
 
 on:
@@ -9,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     defaults:
       run:
         shell: bash -l -e -o pipefail {0}
@@ -25,7 +24,7 @@ jobs:
         run: |
           # Avoid git exiting when Actions runs
           git config --global --add safe.directory "$PWD"
-          
+
           git fetch --tags --force
 
       - name: "Build source package"
@@ -46,9 +45,9 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    
+
     needs: "build"
-    
+
     defaults:
       run:
         shell: bash -l -e -o pipefail {0}
@@ -64,7 +63,7 @@ jobs:
         run: |
           # Avoid git exiting when Actions runs
           git config --global --add safe.directory "$PWD"
-          
+
           git fetch --tags --force
 
       - name: "Get release variables"
@@ -86,15 +85,15 @@ jobs:
           removeArtifacts: true
           artifactErrorsFailBuild: true
           generateReleaseNotes: true
-    
+
     outputs:
       isRelease: ${{ github.sha == env.MASTER_SHA }}
 
   deploy:
     runs-on: ubuntu-latest
-    
+
     needs: [build, release]
-    
+
     # Workaround for https://github.com/actions/runner/issues/1483
     # Actions coerces boolean to string
     if: needs.release.outputs.isRelease == 'true'
@@ -110,7 +109,7 @@ jobs:
         run: |
           # Avoid git exiting when Actions runs
           git config --global --add safe.directory "$PWD"
-          
+
           git fetch --tags --force
 
       - name: "Set up Docker Buildx"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,25 +21,15 @@ jobs:
             build_image: "ghcr.io/wtsi-npg/ub-18.04-irods-clients-dev-4.2.11:latest"
             server_image: "ghcr.io/wtsi-npg/ub-18.04-irods-4.2.11:latest"
             experimental: false
-          # iRODS 4.2.12 clients on Ubuntu 18.04
-          - irods: "4.2.12"
-            build_image: "ghcr.io/wtsi-npg/ub-18.04-irods-clients-dev-4.2.12:latest"
-            server_image: "ghcr.io/wtsi-npg/ub-18.04-irods-4.2.12:latest"
-            experimental: false
-          # iRODS 4.3.1 clients on Ubuntu 22.04
-          - irods: "4.3.1"
-            build_image: "ghcr.io/wtsi-npg/ub-22.04-irods-clients-dev-4.3.1:latest"
-            server_image: "ghcr.io/wtsi-npg/ub-22.04-irods-4.3.1:latest"
-            experimental: false
-          # iRODS 4.3.2 clients on Ubuntu 22.04
-          - irods: "4.3.2"
-            build_image: "ghcr.io/wtsi-npg/ub-22.04-irods-clients-dev-4.3.2:latest"
-            server_image: "ghcr.io/wtsi-npg/ub-22.04-irods-4.3.2:latest"
-            experimental: true
           # iRODS 4.3.3 clients on Ubuntu 22.04
           - irods: "4.3.3"
             build_image: "ghcr.io/wtsi-npg/ub-22.04-irods-clients-dev-4.3.3:latest"
             server_image: "ghcr.io/wtsi-npg/ub-22.04-irods-4.3.3:latest"
+            experimental: false
+          # iRODS 4.3.4 clients on Ubuntu 22.04
+          - irods: "4.3.4"
+            build_image: "ghcr.io/wtsi-npg/ub-22.04-irods-clients-dev-4.3.4:latest"
+            server_image: "ghcr.io/wtsi-npg/ub-22.04-irods-4.3.4:latest"
             experimental: true
 
     services:

--- a/src/baton.c
+++ b/src/baton.c
@@ -254,6 +254,7 @@ int init_rods_path(rodsPath_t *rods_path, char *inpath) {
 
     rods_path->objType  = UNKNOWN_OBJ_T;
     rods_path->objState = UNKNOWN_ST;
+    rods_path->rodsObjStat = NULL;
 
     return 0;
 }


### PR DESCRIPTION
As of iRODS 4.3.4 the memory management semantics of getRodsObjType have changed. It is now required that the rodsObjStat member must be initialised before calling. Previously the call would initialise this member. During the call this member is unconditionally freed, so must be initialised by the caller to avoid a segfault. It's an improvement to initialise this explicitly, anyway.