### PR TITLE
Stop using an emulated get operation

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -308,6 +308,12 @@ Options
   Prints command line help.
 
 .. program:: baton-get
+.. option:: --no-clobber
+
+  When saving data objects to files, raise an error rather than overwrite an
+  existing local file.
+
+.. program:: baton-get
 .. option:: --raw
 
   Prints the contents of the data object instead of a JSON response. In this
@@ -354,6 +360,11 @@ Options
 .. option:: --verbose
 
   Print verbose messages to STDERR.
+
+.. program:: baton-get
+.. option:: --verify
+
+  When saving data objects to files, verify the file checksums after saving.
 
 .. program:: baton-get
 .. option:: --version
@@ -773,8 +784,10 @@ value must be a string naming a ``baton`` operation to be performed
 JSON object. The envelope has one optional property `arguments` which,
 if present, must be a JSON object whose keys and values may be any of
 the command line options permitted for the standard ``baton`` clients
-supporting the previously named operations. Where command line options
-are boolean flags, a JSON `true` value should be used.
+supporting the previously named operations (without the leading `--`,
+e.g. the `--no-clobber` option for `get` becomes `no-clobber`). Where
+command line options are boolean flags, a JSON `true` value should be
+used.
 
 Options
 ^^^^^^^

--- a/src/operations.c
+++ b/src/operations.c
@@ -558,7 +558,6 @@ json_t *baton_json_get_op(rodsEnv *env, rcComm_t *conn, json_t *target,
     if (error->code != 0) goto finally;
 
     const size_t bsize = args->buffer_size;
-    logmsg(DEBUG, "Using a 'get' buffer size of %zu bytes", bsize);
 
     if (args->flags & SAVE_FILES) {
         result = json_deep_copy(target);
@@ -567,7 +566,7 @@ json_t *baton_json_get_op(rodsEnv *env, rcComm_t *conn, json_t *target,
                             "Failed to allocate memory for result");
             goto finally;
         }
-        get_data_obj_file(conn, &rods_path, file, bsize, error);
+        get_data_obj_file(conn, &rods_path, file, args->flags, error);
         if (error->code != 0) goto finally;
     }
     else if (args->flags & PRINT_RAW) {

--- a/src/read.h
+++ b/src/read.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2014, 2015, 2016, 2017, 2018, 2021 Genome Research
+ * Copyright (C) 2014, 2015, 2016, 2017, 2018, 2021, 2025 Genome Research
  * Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -116,9 +116,8 @@ json_t *ingest_data_obj(rcComm_t *conn, rodsPath_t *rods_path,
                         option_flags flags,
                         size_t buffer_size, baton_error_t *error);
 
-int get_data_obj_file(rcComm_t *conn, rodsPath_t *rods_path,
-                      const char *local_path, size_t buffer_size,
-                      baton_error_t *error);
+int get_data_obj_file(rcComm_t *conn, rodsPath_t *rods_path, const char *local_path,
+                      option_flags flags, baton_error_t *error);
 
 int get_data_obj_stream(rcComm_t *conn, rodsPath_t *rods_path, FILE *out,
                         size_t buffer_size, baton_error_t *error);


### PR DESCRIPTION
Stop using an emulated get operation (which actually uses the open/read/close API to stream data and a stream checksum check, behind the scenes) and use the real get API.

This allows us to have a new --verify option on baton-get/baton-do to enable full, at-rest checksums when downloading to files (i.e. when using --save), using get's built-in check to do this (currently on-the-fly checksums, not at-rest).

As get uses parallel chunk download for large files (>32MiB), that part of the operation is likely to be faster than before. However, at-rest checksums will take additional time, so there will be a penalty there.

If the performance penalty of at-rest checksums is not acceptable, avoiding use of the --verify flag should retain current speed. In doing so, we will lose the on-the-fly checksum. However, an at-rest checksum is by far the more preferable option for data integrity and the effectiveness of the on-the-fly checksum is debatable.

There will be a new --no-clobber option to enable get's local file protection, but baton's default of clobbering local files will remain, so that pipelines using it are idempotent by default. Pipelines requiring local file protection can enable --no-clobber and then become responsible for cleaning/re-trying failed downloads their own way.