### PR TITLE
Fix for possible OOB writes when a user builds a large query.

### DIFF
--- a/src/json_query.c
+++ b/src/json_query.c
@@ -20,7 +20,9 @@
  * @author Joshua C. Randall <jcrandall@alum.mit.edu>
  */
 
+#include <errno.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <jansson.h>
 
@@ -101,6 +103,26 @@ static const char* map_access_level(const char *access_level, baton_error_t *err
                     ACCESS_LEVEL_NULL, ACCESS_LEVEL_OWN, ACCESS_LEVEL_READ,
                     ACCESS_LEVEL_WRITE);
     return NULL;
+}
+
+static void set_query_prepare_error(const char *context, baton_error_t *error) {
+    const int errnum = errno;
+
+    init_baton_error(error);
+
+    if (errnum == EOVERFLOW) {
+        set_baton_error(error, CAT_INVALID_ARGUMENT,
+                        "Query exceeded the maximum of %d conditions while "
+                        "preparing %s constraints", MAX_NUM_CONDITIONS, context);
+    }
+    else if (errnum != 0) {
+        set_baton_error(error, errnum,
+                        "Failed to prepare %s constraints: error %d %s", context, errnum,
+                        strerror(errnum));
+    }
+    else {
+        set_baton_error(error, -1, "Failed to prepare %s constraints", context);
+    }
 }
 
 // Map an iCAT token back to a user-visible access level.
@@ -208,8 +230,8 @@ const char* ensure_valid_operator(const char *op, baton_error_t *error) {
     };
     init_baton_error(error);
 
-    size_t valid_index;
-    int valid = 0;
+    size_t valid_index = 0;
+    int valid          = 0;
     for (size_t i = 0; i < num_operators; i++) {
         if (str_equals_ignore_case(op, operators[i], MAX_STR_LEN)) {
             valid       = 1;
@@ -258,6 +280,10 @@ json_t* do_search(rcComm_t *conn,
     }
 
     query_in = make_query_input(SEARCH_MAX_ROWS, format->num_columns, format->columns);
+    if (!query_in) {
+        set_query_prepare_error("query", error);
+        goto error;
+    }
 
     if (root_path) {
         rodsPath_t rods_path;
@@ -278,6 +304,10 @@ json_t* do_search(rcComm_t *conn,
             else {
                 logmsg(DEBUG, "Limiting search to path '%s'", root_path);
                 query_in = prepare_path_search(query_in, root_path);
+                if (!query_in) {
+                    set_query_prepare_error("path", error);
+                    goto error;
+                }
             }
         }
     }
@@ -287,11 +317,15 @@ json_t* do_search(rcComm_t *conn,
     if (error->code != 0) goto error;
 
     query_in = prepare_json_avu_search(query_in, avus, prepare_avu, error);
-    if (error->code != 0) goto error;
+    if (error->code != 0 || !query_in) goto error;
 
     // Report good replicates only
     if (format->good_repl) {
         query_in = limit_to_good_repl(query_in);
+        if (!query_in) {
+            set_query_prepare_error("replica", error);
+            goto error;
+        }
     }
 
     // ACL is optional
@@ -300,7 +334,7 @@ json_t* do_search(rcComm_t *conn,
         if (error->code != 0) goto error;
 
         query_in = prepare_json_acl_search(query_in, acl, prepare_acl, error);
-        if (error->code != 0) goto error;
+        if (error->code != 0 || !query_in) goto error;
     }
 
     // Timestamp is optional
@@ -310,7 +344,7 @@ json_t* do_search(rcComm_t *conn,
 
         query_in = prepare_json_tps_search(query_in, tps, prepare_cre,
                                            prepare_mod, error);
-        if (error->code != 0) goto error;
+        if (error->code != 0 || !query_in) goto error;
     }
 
     if (zone_hint) {
@@ -681,6 +715,10 @@ genQueryInp_t* prepare_json_acl_search(genQueryInp_t *query_in,
         if (error->code != 0) goto error;
 
         query_in = prepare(query_in, owner_name, access_level);
+        if (!query_in) {
+            set_query_prepare_error("ACL", error);
+            goto error;
+        }
     }
 
     return query_in;
@@ -693,8 +731,6 @@ genQueryInp_t* prepare_json_avu_search(genQueryInp_t *query_in,
                                        const json_t *avus,
                                        const prepare_avu_search_cb prepare,
                                        baton_error_t *error) {
-    json_t *in_opvalue = NULL;
-
     init_baton_error(error);
 
     const size_t num_clauses = json_array_size(avus);
@@ -735,18 +771,16 @@ genQueryInp_t* prepare_json_avu_search(genQueryInp_t *query_in,
         logmsg(DEBUG, "Preparing AVU search a: '%s' v: '%s', op: '%s'", attr_name,
                attr_value, valid_oper);
 
-        prepare(query_in, attr_name, attr_value, valid_oper);
-
-        if (in_opvalue) {
-            json_decref(in_opvalue);
-            in_opvalue = NULL; // Reset for any subsequent IN clause
+        query_in = prepare(query_in, attr_name, attr_value, valid_oper);
+        if (!query_in) {
+            set_query_prepare_error("AVU", error);
+            goto error;
         }
     }
 
     return query_in;
 
 error:
-    if (in_opvalue) json_decref(in_opvalue);
     return query_in;
 }
 
@@ -853,7 +887,12 @@ genQueryInp_t* prepare_json_tps_search(genQueryInp_t *query_in,
             goto error;
         }
 
-        prepare(query_in, raw_timestamp, oper);
+        query_in = prepare(query_in, raw_timestamp, oper);
+        if (!query_in) {
+            free(raw_timestamp);
+            set_query_prepare_error("timestamp", error);
+            goto error;
+        }
         free(raw_timestamp);
     }
 
@@ -1197,8 +1236,6 @@ error:
 }
 
 json_t* map_access_args(json_t *query, baton_error_t *error) {
-    json_t *user_info = NULL;
-
     init_baton_error(error);
 
     if (has_acl(query)) {
@@ -1233,8 +1270,6 @@ json_t* map_access_args(json_t *query, baton_error_t *error) {
     return query;
 
 error:
-    if (user_info) json_decref(user_info);
-
     return NULL;
 }
 

--- a/src/query.c
+++ b/src/query.c
@@ -50,19 +50,24 @@ void log_rods_errstack(const log_level level, const rError_t *error) {
 genQueryInp_t* make_query_input(const size_t max_rows,
                                 const size_t num_columns,
                                 const int columns[]) {
+    int *cols_to_select = NULL;
+    int *special_select_ops = NULL;
+    int *query_cond_indices = NULL;
+    char **query_cond_values = NULL;
+
     genQueryInp_t *query_in = calloc(1, sizeof (genQueryInp_t));
     if (!query_in) goto error;
 
     logmsg(DEBUG, "Preparing a query to select %d columns", num_columns);
 
-    int *cols_to_select = calloc(num_columns, sizeof(int));
+    cols_to_select = calloc(num_columns, sizeof(int));
     if (!cols_to_select) goto error;
 
     for (size_t i = 0; i < num_columns; i++) {
         cols_to_select[i] = columns[i];
     }
 
-    int *special_select_ops = calloc(num_columns, sizeof(int));
+    special_select_ops = calloc(num_columns, sizeof(int));
     if (!special_select_ops) goto error;
 
     special_select_ops[0] = 0;
@@ -75,10 +80,10 @@ genQueryInp_t* make_query_input(const size_t max_rows,
     query_in->continueInx   = 0;
     query_in->condInput.len = 0;
 
-    int *query_cond_indices = calloc(MAX_NUM_CONDITIONS, sizeof(int));
+    query_cond_indices = calloc(MAX_NUM_CONDITIONS, sizeof(int));
     if (!query_cond_indices) goto error;
 
-    char **query_cond_values = calloc(MAX_NUM_CONDITIONS, sizeof(char *));
+    query_cond_values = calloc(MAX_NUM_CONDITIONS, sizeof(char *));
     if (!query_cond_values) goto error;
 
     query_in->sqlCondInp.inx   = query_cond_indices;
@@ -89,6 +94,10 @@ genQueryInp_t* make_query_input(const size_t max_rows,
 
 error:
     logmsg(ERROR, "Failed to allocate memory: error %d %s", errno, strerror(errno));
+    if (cols_to_select) free(cols_to_select);
+    if (special_select_ops) free(special_select_ops);
+    if (query_cond_indices) free(query_cond_indices);
+    if (query_cond_values) free(query_cond_values);
 
     return NULL;
 }
@@ -139,6 +148,19 @@ void free_query_output(genQueryOut_t *query_out) {
 genQueryInp_t* add_query_conds(genQueryInp_t *query_in,
                                const size_t num_conds,
                                const query_cond_t conds[]) {
+    if (!query_in) {
+        errno = EINVAL;
+        goto error;
+    }
+
+    if (query_in->sqlCondInp.len + num_conds > MAX_NUM_CONDITIONS) {
+        logmsg(ERROR, "Failed to add %zu query conditions; %d are already present "
+               "and the maximum is %d", num_conds, query_in->sqlCondInp.len,
+               MAX_NUM_CONDITIONS);
+        errno = EOVERFLOW;
+        goto error;
+    }
+
     for (size_t i = 0; i < num_conds; i++) {
         char *column = getAttrNameFromAttrId(conds[i].column);
         const char *operator = conds[i]
@@ -226,6 +248,8 @@ genQueryInp_t* prepare_obj_list(genQueryInp_t *query_in,
 
 error:
     logmsg(ERROR, "Failed to allocate memory: error %d %s", errno, strerror(errno));
+    if (path1) free(path1);
+    if (path2) free(path2);
 
     return NULL;
 }
@@ -324,6 +348,8 @@ genQueryInp_t* prepare_obj_repl_list(genQueryInp_t *query_in, rodsPath_t *rods_p
 
 error:
     logmsg(ERROR, "Failed to allocate memory: error %d %s", errno, strerror(errno));
+    if (path1) free(path1);
+    if (path2) free(path2);
 
     return NULL;
 }

--- a/tests/check_baton.c
+++ b/tests/check_baton.c
@@ -19,6 +19,7 @@
  */
 
 #include <assert.h>
+#include <errno.h>
 #include <limits.h>
 #include <unistd.h>
 
@@ -33,6 +34,7 @@
 #include "../src/compat_checksum.h"
 #include "../src/signal_handler.h"
 #include "../src/operations.h"
+#include "../src/query.h"
 #include "../src/write.h"
 
 int exit_flag;
@@ -730,6 +732,32 @@ START_TEST(test_make_query_input) {
 
     ck_assert_ptr_ne(query_input->sqlCondInp.inx, NULL);
     ck_assert_ptr_ne(query_input->sqlCondInp.value, NULL);
+    ck_assert_int_eq(query_input->sqlCondInp.len, 0);
+
+    free_query_input(query_input);
+}
+END_TEST
+
+START_TEST(test_add_query_conds_rejects_too_many_conditions) {
+    const int max_rows = 10;
+    const int num_columns = 1;
+    const int columns[] = { COL_COLL_NAME };
+    genQueryInp_t *query_input = make_query_input(max_rows, num_columns, columns);
+
+    ck_assert_ptr_ne(query_input, NULL);
+
+    query_cond_t conds[MAX_NUM_CONDITIONS + 1];
+    for (size_t i = 0; i < MAX_NUM_CONDITIONS + 1; i++) {
+        conds[i] = (query_cond_t) {
+            .column = COL_COLL_NAME,
+            .operator = SEARCH_OP_EQUALS,
+            .value = "test"
+        };
+    }
+
+    errno = 0;
+    ck_assert_ptr_eq(add_query_conds(query_input, MAX_NUM_CONDITIONS + 1, conds), NULL);
+    ck_assert_int_eq(errno, EOVERFLOW);
     ck_assert_int_eq(query_input->sqlCondInp.len, 0);
 
     free_query_input(query_input);
@@ -3102,6 +3130,7 @@ Suite *baton_suite(void) {
     tcase_add_test(basic, test_init_rods_path);
     tcase_add_test(basic, test_resolve_rods_path);
     tcase_add_test(basic, test_make_query_input);
+    tcase_add_test(basic, test_add_query_conds_rejects_too_many_conditions);
 
      TCase *path = tcase_create("path");
      tcase_add_unchecked_fixture(path, setup, teardown);


### PR DESCRIPTION
Add a bounds check for the maximum permitted number of query parameters.

Add a test for exceeding the maximum.

Add some initialisation for variables potentially uninitialised.

Add free() on some error paths to avoid memory leaks.

Removed some unused variables and checks.