### PR TITLE
Fix for possible OOB writes when running the specificquery client

### DIFF
--- a/src/json_query.c
+++ b/src/json_query.c
@@ -20,7 +20,9 @@
  * @author Joshua C. Randall <jcrandall@alum.mit.edu>
  */
 
+#include <errno.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <jansson.h>
 
@@ -101,6 +103,26 @@ static const char* map_access_level(const char *access_level, baton_error_t *err
                     ACCESS_LEVEL_NULL, ACCESS_LEVEL_OWN, ACCESS_LEVEL_READ,
                     ACCESS_LEVEL_WRITE);
     return NULL;
+}
+
+static void set_query_prepare_error(const char *context, baton_error_t *error) {
+    const int errnum = errno;
+
+    init_baton_error(error);
+
+    if (errnum == EOVERFLOW) {
+        set_baton_error(error, CAT_INVALID_ARGUMENT,
+                        "Query exceeded the maximum of %d conditions while "
+                        "preparing %s constraints", MAX_NUM_CONDITIONS, context);
+    }
+    else if (errnum != 0) {
+        set_baton_error(error, errnum,
+                        "Failed to prepare %s constraints: error %d %s", context, errnum,
+                        strerror(errnum));
+    }
+    else {
+        set_baton_error(error, -1, "Failed to prepare %s constraints", context);
+    }
 }
 
 // Map an iCAT token back to a user-visible access level.
@@ -208,8 +230,8 @@ const char* ensure_valid_operator(const char *op, baton_error_t *error) {
     };
     init_baton_error(error);
 
-    size_t valid_index;
-    int valid = 0;
+    size_t valid_index = 0;
+    int valid          = 0;
     for (size_t i = 0; i < num_operators; i++) {
         if (str_equals_ignore_case(op, operators[i], MAX_STR_LEN)) {
             valid       = 1;
@@ -258,6 +280,10 @@ json_t* do_search(rcComm_t *conn,
     }
 
     query_in = make_query_input(SEARCH_MAX_ROWS, format->num_columns, format->columns);
+    if (!query_in) {
+        set_query_prepare_error("query", error);
+        goto error;
+    }
 
     if (root_path) {
         rodsPath_t rods_path;
@@ -278,6 +304,10 @@ json_t* do_search(rcComm_t *conn,
             else {
                 logmsg(DEBUG, "Limiting search to path '%s'", root_path);
                 query_in = prepare_path_search(query_in, root_path);
+                if (!query_in) {
+                    set_query_prepare_error("path", error);
+                    goto error;
+                }
             }
         }
     }
@@ -287,11 +317,15 @@ json_t* do_search(rcComm_t *conn,
     if (error->code != 0) goto error;
 
     query_in = prepare_json_avu_search(query_in, avus, prepare_avu, error);
-    if (error->code != 0) goto error;
+    if (error->code != 0 || !query_in) goto error;
 
     // Report good replicates only
     if (format->good_repl) {
         query_in = limit_to_good_repl(query_in);
+        if (!query_in) {
+            set_query_prepare_error("replica", error);
+            goto error;
+        }
     }
 
     // ACL is optional
@@ -300,7 +334,7 @@ json_t* do_search(rcComm_t *conn,
         if (error->code != 0) goto error;
 
         query_in = prepare_json_acl_search(query_in, acl, prepare_acl, error);
-        if (error->code != 0) goto error;
+        if (error->code != 0 || !query_in) goto error;
     }
 
     // Timestamp is optional
@@ -310,7 +344,7 @@ json_t* do_search(rcComm_t *conn,
 
         query_in = prepare_json_tps_search(query_in, tps, prepare_cre,
                                            prepare_mod, error);
-        if (error->code != 0) goto error;
+        if (error->code != 0 || !query_in) goto error;
     }
 
     if (zone_hint) {
@@ -681,6 +715,10 @@ genQueryInp_t* prepare_json_acl_search(genQueryInp_t *query_in,
         if (error->code != 0) goto error;
 
         query_in = prepare(query_in, owner_name, access_level);
+        if (!query_in) {
+            set_query_prepare_error("ACL", error);
+            goto error;
+        }
     }
 
     return query_in;
@@ -693,8 +731,6 @@ genQueryInp_t* prepare_json_avu_search(genQueryInp_t *query_in,
                                        const json_t *avus,
                                        const prepare_avu_search_cb prepare,
                                        baton_error_t *error) {
-    json_t *in_opvalue = NULL;
-
     init_baton_error(error);
 
     const size_t num_clauses = json_array_size(avus);
@@ -735,18 +771,16 @@ genQueryInp_t* prepare_json_avu_search(genQueryInp_t *query_in,
         logmsg(DEBUG, "Preparing AVU search a: '%s' v: '%s', op: '%s'", attr_name,
                attr_value, valid_oper);
 
-        prepare(query_in, attr_name, attr_value, valid_oper);
-
-        if (in_opvalue) {
-            json_decref(in_opvalue);
-            in_opvalue = NULL; // Reset for any subsequent IN clause
+        query_in = prepare(query_in, attr_name, attr_value, valid_oper);
+        if (!query_in) {
+            set_query_prepare_error("AVU", error);
+            goto error;
         }
     }
 
     return query_in;
 
 error:
-    if (in_opvalue) json_decref(in_opvalue);
     return query_in;
 }
 
@@ -853,7 +887,12 @@ genQueryInp_t* prepare_json_tps_search(genQueryInp_t *query_in,
             goto error;
         }
 
-        prepare(query_in, raw_timestamp, oper);
+        query_in = prepare(query_in, raw_timestamp, oper);
+        if (!query_in) {
+            free(raw_timestamp);
+            set_query_prepare_error("timestamp", error);
+            goto error;
+        }
         free(raw_timestamp);
     }
 
@@ -1197,8 +1236,6 @@ error:
 }
 
 json_t* map_access_args(json_t *query, baton_error_t *error) {
-    json_t *user_info = NULL;
-
     init_baton_error(error);
 
     if (has_acl(query)) {
@@ -1233,8 +1270,6 @@ json_t* map_access_args(json_t *query, baton_error_t *error) {
     return query;
 
 error:
-    if (user_info) json_decref(user_info);
-
     return NULL;
 }
 

--- a/src/json_query.c
+++ b/src/json_query.c
@@ -389,7 +389,7 @@ json_t* do_specific(rcComm_t *conn,
     if (error->code != 0) goto error;
 
     format = prepare_json_specific_labels(conn, specific, prepare_labels, error);
-    if (error->code != 0) goto error;
+    if (error->code != 0 || !format) goto error;
 
     if (zone_name) {
         logmsg(TRACE, "Setting zone to '%s'", zone_name);
@@ -542,6 +542,14 @@ json_t* do_squery(rcComm_t *conn,
         int status = rcSpecificQuery(conn, squery_in, &query_out);
         if (status == 0) {
             logmsg(DEBUG, "Successfully fetched chunk %d of query", chunk_num);
+
+            const size_t num_attr = query_out->attriCnt;
+            if (num_attr > MAX_NUM_COLUMNS) {
+                set_baton_error(error, CAT_INVALID_ARGUMENT,
+                                "Specific query result exceeded maximum of %d columns "
+                                "(got %lu)", MAX_NUM_COLUMNS, num_attr);
+                goto error;
+            }
 
             // Allows query_out to be freed
             continue_flag = query_out->continueInx;
@@ -799,7 +807,12 @@ specificQueryInp_t* prepare_json_specific_query(specificQueryInp_t *squery_in,
 
     logmsg(DEBUG, "Preparing specific search s: '%s'", sql);
 
-    prepare(squery_in, sql, args);
+    specificQueryInp_t *prepared = prepare(squery_in, sql, args);
+    if (!prepared) {
+        set_query_prepare_error("specific query", error);
+        goto error;
+    }
+    squery_in = prepared;
 
     if (args) {
         json_decref(args);
@@ -825,6 +838,10 @@ query_format_in_t* prepare_json_specific_labels(rcComm_t *conn,
     logmsg(DEBUG, "Preparing labels for specific search: '%s'", sql);
 
     format = prepare(conn, sql);
+    if (!format) {
+        set_query_prepare_error("specific query labels", error);
+        goto error;
+    }
 
     return format;
 

--- a/src/query.c
+++ b/src/query.c
@@ -585,12 +585,23 @@ specificQueryInp_t* prepare_specific_query(specificQueryInp_t *squery_in,
     squery_in->continueInx = 0;
     squery_in->sql         = (char *) sql;
 
-    json_array_foreach(args, index, value)
-    {
+    json_array_foreach(args, index, value) {
+        if (index >= MAX_SPECIFIC_QUERY_ARGS) {
+            errno = EOVERFLOW;
+            logmsg(ERROR, "Specific query args exceeded maximum of %d entries",
+                   MAX_SPECIFIC_QUERY_ARGS);
+            goto error;
+        }
+
         if (json_is_string(value)) {
             squery_in->args[index] = strdup(json_string_value(value));
+            if (!squery_in->args[index]) {
+                errno = ENOMEM;
+                goto error;
+            }
         }
         else {
+            errno = EINVAL;
             goto error;
         }
     }
@@ -598,14 +609,14 @@ specificQueryInp_t* prepare_specific_query(specificQueryInp_t *squery_in,
     return squery_in;
 
 error:
-    logmsg(ERROR, "Failed to parse JSON specific query args: %s", args);
-    return squery_in;
+    logmsg(ERROR, "Failed to parse JSON specific query args");
+    return NULL;
 }
 
 void free_squery_input(specificQueryInp_t *squery_in) {
     assert(squery_in);
 
-    for (unsigned int i = 0; i < 10; i++) {
+    for (unsigned int i = 0; i < MAX_SPECIFIC_QUERY_ARGS; i++) {
         if (squery_in->args[i] != NULL) {
             free(squery_in->args[i]);
         }
@@ -634,9 +645,13 @@ query_format_in_t* make_query_format_from_sql(const char *sql) {
     enum { as_column_name_capt_idx = 1 };
     regex_t as_column_name_capt_re;
 
-    char *select_list, *select_list_tokenize;
+    char *select_list = NULL, *select_list_tokenize = NULL;
     char *column_trim, *column_name;
     unsigned int i;
+
+    int select_list_capt_re_compiled = 0;
+    int trim_whitespace_capt_re_compiled = 0;
+    int as_column_name_capt_re_compiled = 0;
 
     unsigned int reti = regcomp(&select_list_capt_re, select_list_capt_re_str,
                                 REG_EXTENDED | REG_ICASE);
@@ -646,6 +661,7 @@ query_format_in_t* make_query_format_from_sql(const char *sql) {
                remsg);
         goto error;
     }
+    select_list_capt_re_compiled = 1;
 
     reti = regcomp(&trim_whitespace_capt_re, trim_whitespace_capt_re_str,
                    REG_EXTENDED | REG_ICASE);
@@ -655,6 +671,7 @@ query_format_in_t* make_query_format_from_sql(const char *sql) {
                remsg);
         goto error;
     }
+    trim_whitespace_capt_re_compiled = 1;
 
     reti = regcomp(&as_column_name_capt_re, as_column_name_capt_re_str,
                    REG_EXTENDED | REG_ICASE);
@@ -664,6 +681,7 @@ query_format_in_t* make_query_format_from_sql(const char *sql) {
                remsg);
         goto error;
     }
+    as_column_name_capt_re_compiled = 1;
 
     format = calloc(1, sizeof(query_format_in_t));
     if (!format) goto error;
@@ -698,6 +716,13 @@ query_format_in_t* make_query_format_from_sql(const char *sql) {
 
     // parse select_list_tokenize column by column
     for (i = 0; select_list_tokenize != NULL; i++) {
+        if (i >= MAX_NUM_COLUMNS) {
+            errno = EOVERFLOW;
+            logmsg(ERROR, "Specific query SELECT list exceeded maximum of %d columns",
+                   MAX_NUM_COLUMNS);
+            goto error;
+        }
+
         regmatch_t trim_whitespace_pmatch[trim_whitespace_capt_idx + 1];
         regmatch_t as_column_name_pmatch[as_column_name_capt_idx + 1];
         // get next column specification from select_list_tokenize
@@ -777,17 +802,23 @@ query_format_in_t* make_query_format_from_sql(const char *sql) {
 error_recoverable:
     logmsg(ERROR, "Could not parse select columns from SQL " "into query format: '%s'",
            sql);
-    // create generic columns labels as a backup plan
-    format->num_columns = MAX_NUM_COLUMNS;
-    for (i = 0; i < (format->num_columns - 1); i++) {
-        if (format->labels[i] == NULL) {
-            reti = asprintf((char **) &format->labels[i], "col%d", i);
-        }
-    }
-    return format;
+    goto error;
 
 error:
     logmsg(ERROR, "Could not process SQL: '%s'", sql);
+    if (select_list) free(select_list);
+    if (format) {
+        for (i = 0; i < MAX_NUM_COLUMNS; i++) {
+            // iRODS defines these labels as const char *
+            if (format->labels[i]) free((void *) format->labels[i]);
+        }
+        free(format);
+    }
+
+    if (select_list_capt_re_compiled) regfree(&select_list_capt_re);
+    if (trim_whitespace_capt_re_compiled) regfree(&trim_whitespace_capt_re);
+    if (as_column_name_capt_re_compiled) regfree(&as_column_name_capt_re);
+
     return NULL;
 }
 

--- a/src/query.c
+++ b/src/query.c
@@ -50,19 +50,24 @@ void log_rods_errstack(const log_level level, const rError_t *error) {
 genQueryInp_t* make_query_input(const size_t max_rows,
                                 const size_t num_columns,
                                 const int columns[]) {
+    int *cols_to_select = NULL;
+    int *special_select_ops = NULL;
+    int *query_cond_indices = NULL;
+    char **query_cond_values = NULL;
+
     genQueryInp_t *query_in = calloc(1, sizeof (genQueryInp_t));
     if (!query_in) goto error;
 
     logmsg(DEBUG, "Preparing a query to select %d columns", num_columns);
 
-    int *cols_to_select = calloc(num_columns, sizeof(int));
+    cols_to_select = calloc(num_columns, sizeof(int));
     if (!cols_to_select) goto error;
 
     for (size_t i = 0; i < num_columns; i++) {
         cols_to_select[i] = columns[i];
     }
 
-    int *special_select_ops = calloc(num_columns, sizeof(int));
+    special_select_ops = calloc(num_columns, sizeof(int));
     if (!special_select_ops) goto error;
 
     special_select_ops[0] = 0;
@@ -75,10 +80,10 @@ genQueryInp_t* make_query_input(const size_t max_rows,
     query_in->continueInx   = 0;
     query_in->condInput.len = 0;
 
-    int *query_cond_indices = calloc(MAX_NUM_CONDITIONS, sizeof(int));
+    query_cond_indices = calloc(MAX_NUM_CONDITIONS, sizeof(int));
     if (!query_cond_indices) goto error;
 
-    char **query_cond_values = calloc(MAX_NUM_CONDITIONS, sizeof(char *));
+    query_cond_values = calloc(MAX_NUM_CONDITIONS, sizeof(char *));
     if (!query_cond_values) goto error;
 
     query_in->sqlCondInp.inx   = query_cond_indices;
@@ -89,6 +94,10 @@ genQueryInp_t* make_query_input(const size_t max_rows,
 
 error:
     logmsg(ERROR, "Failed to allocate memory: error %d %s", errno, strerror(errno));
+    if (cols_to_select) free(cols_to_select);
+    if (special_select_ops) free(special_select_ops);
+    if (query_cond_indices) free(query_cond_indices);
+    if (query_cond_values) free(query_cond_values);
 
     return NULL;
 }
@@ -139,6 +148,19 @@ void free_query_output(genQueryOut_t *query_out) {
 genQueryInp_t* add_query_conds(genQueryInp_t *query_in,
                                const size_t num_conds,
                                const query_cond_t conds[]) {
+    if (!query_in) {
+        errno = EINVAL;
+        goto error;
+    }
+
+    if (query_in->sqlCondInp.len + num_conds > MAX_NUM_CONDITIONS) {
+        logmsg(ERROR, "Failed to add %zu query conditions; %d are already present "
+               "and the maximum is %d", num_conds, query_in->sqlCondInp.len,
+               MAX_NUM_CONDITIONS);
+        errno = EOVERFLOW;
+        goto error;
+    }
+
     for (size_t i = 0; i < num_conds; i++) {
         char *column = getAttrNameFromAttrId(conds[i].column);
         const char *operator = conds[i]
@@ -226,6 +248,8 @@ genQueryInp_t* prepare_obj_list(genQueryInp_t *query_in,
 
 error:
     logmsg(ERROR, "Failed to allocate memory: error %d %s", errno, strerror(errno));
+    if (path1) free(path1);
+    if (path2) free(path2);
 
     return NULL;
 }
@@ -324,6 +348,8 @@ genQueryInp_t* prepare_obj_repl_list(genQueryInp_t *query_in, rodsPath_t *rods_p
 
 error:
     logmsg(ERROR, "Failed to allocate memory: error %d %s", errno, strerror(errno));
+    if (path1) free(path1);
+    if (path2) free(path2);
 
     return NULL;
 }

--- a/src/query.h
+++ b/src/query.h
@@ -30,6 +30,7 @@
 
 #define MAX_NUM_COLUMNS     128
 #define MAX_NUM_CONDITIONS   32
+#define MAX_SPECIFIC_QUERY_ARGS 10
 
 #define SEARCH_MAX_ROWS      10
 

--- a/tests/check_baton.c
+++ b/tests/check_baton.c
@@ -2772,6 +2772,87 @@ START_TEST(test_search_specific_with_valid_setup) {
 }
 END_TEST
 
+START_TEST(test_prepare_specific_query_rejects_too_many_args) {
+    specificQueryInp_t *squery_in = calloc(1, sizeof(specificQueryInp_t));
+    ck_assert_ptr_ne(squery_in, NULL);
+
+    json_t *args = json_array();
+    ck_assert_ptr_ne(args, NULL);
+
+    for (size_t i = 0; i < MAX_SPECIFIC_QUERY_ARGS + 1; i++) {
+        const int status = json_array_append_new(args, json_string("arg"));
+        ck_assert_int_eq(status, 0);
+    }
+
+    errno = 0;
+    ck_assert_ptr_eq(prepare_specific_query(squery_in, "select 1", args), NULL);
+    ck_assert_int_eq(errno, EOVERFLOW);
+
+    free_squery_input(squery_in);
+    json_decref(args);
+}
+END_TEST
+
+START_TEST(test_make_query_format_from_sql_rejects_too_many_columns) {
+    char sql[8192];
+    size_t offset = snprintf(sql, sizeof(sql), "SELECT ");
+    ck_assert(offset < sizeof(sql));
+
+    for (size_t i = 0; i < MAX_NUM_COLUMNS + 1; i++) {
+        const char *fmt = (i == MAX_NUM_COLUMNS) ? "col_%zu" : "col_%zu, ";
+        offset += snprintf(sql + offset, sizeof(sql) - offset, fmt, i);
+        ck_assert(offset < sizeof(sql));
+    }
+    offset += snprintf(sql + offset, sizeof(sql) - offset, " FROM t");
+    ck_assert(offset < sizeof(sql));
+
+    errno = 0;
+    const query_format_in_t *format = make_query_format_from_sql(sql);
+    ck_assert_ptr_eq(format, NULL);
+    ck_assert_int_eq(errno, EOVERFLOW);
+}
+END_TEST
+
+
+START_TEST(test_search_specific_rejects_too_many_args) {
+    baton_session_t *session = new_baton_session();
+
+    int status = baton_connect(session);
+    ck_assert_int_eq(status, 0);
+
+    json_t *args = json_array();
+    ck_assert_ptr_ne(args, NULL);
+
+    for (size_t i = 0; i < MAX_SPECIFIC_QUERY_ARGS + 1; i++) {
+        status = json_array_append_new(args, json_string("arg"));
+        ck_assert_int_eq(status, 0);
+    }
+
+    json_t *specific = json_object();
+    ck_assert_ptr_ne(specific, NULL);
+    status = json_object_set_new(specific, JSON_SQL_KEY, json_string("select 1"));
+    ck_assert_int_eq(status, 0);
+    status = json_object_set_new(specific, JSON_ARGS_KEY, args);
+    ck_assert_int_eq(status, 0);
+
+    json_t *query_json = json_object();
+    ck_assert_ptr_ne(query_json, NULL);
+    status = json_object_set_new(query_json, JSON_SPECIFIC_KEY, specific);
+    ck_assert_int_eq(status, 0);
+
+    baton_error_t search_error;
+    json_t *search_results = search_specific(session->conn, query_json, NULL,
+                                             &search_error);
+    ck_assert_ptr_eq(search_results, NULL);
+    ck_assert_int_eq(search_error.code, CAT_INVALID_ARGUMENT);
+
+    json_decref(query_json);
+
+    baton_disconnect(session);
+    free_baton_session(session);
+}
+END_TEST
+
 START_TEST(test_exit_flag_on_sigint) {
     apply_signal_handler();
     raise(SIGINT);
@@ -3209,6 +3290,12 @@ Suite *baton_suite(void) {
                     test_make_query_format_from_sql_with_select_query_using_column_alias);
      tcase_add_test(specific_query,
                     test_make_query_format_from_sql_with_invalid_query);
+     tcase_add_test(specific_query,
+                    test_prepare_specific_query_rejects_too_many_args);
+     tcase_add_test(specific_query,
+                    test_make_query_format_from_sql_rejects_too_many_columns);
+     tcase_add_test(specific_query,
+               test_search_specific_rejects_too_many_args);
      tcase_add_test(specific_query,
                     test_search_specific_with_valid_setup);
 

--- a/tests/check_baton.c
+++ b/tests/check_baton.c
@@ -19,6 +19,7 @@
  */
 
 #include <assert.h>
+#include <errno.h>
 #include <limits.h>
 #include <unistd.h>
 
@@ -33,6 +34,7 @@
 #include "../src/compat_checksum.h"
 #include "../src/signal_handler.h"
 #include "../src/operations.h"
+#include "../src/query.h"
 #include "../src/write.h"
 
 int exit_flag;
@@ -730,6 +732,32 @@ START_TEST(test_make_query_input) {
 
     ck_assert_ptr_ne(query_input->sqlCondInp.inx, NULL);
     ck_assert_ptr_ne(query_input->sqlCondInp.value, NULL);
+    ck_assert_int_eq(query_input->sqlCondInp.len, 0);
+
+    free_query_input(query_input);
+}
+END_TEST
+
+START_TEST(test_add_query_conds_rejects_too_many_conditions) {
+    const int max_rows = 10;
+    const int num_columns = 1;
+    const int columns[] = { COL_COLL_NAME };
+    genQueryInp_t *query_input = make_query_input(max_rows, num_columns, columns);
+
+    ck_assert_ptr_ne(query_input, NULL);
+
+    query_cond_t conds[MAX_NUM_CONDITIONS + 1];
+    for (size_t i = 0; i < MAX_NUM_CONDITIONS + 1; i++) {
+        conds[i] = (query_cond_t) {
+            .column = COL_COLL_NAME,
+            .operator = SEARCH_OP_EQUALS,
+            .value = "test"
+        };
+    }
+
+    errno = 0;
+    ck_assert_ptr_eq(add_query_conds(query_input, MAX_NUM_CONDITIONS + 1, conds), NULL);
+    ck_assert_int_eq(errno, EOVERFLOW);
     ck_assert_int_eq(query_input->sqlCondInp.len, 0);
 
     free_query_input(query_input);
@@ -3102,6 +3130,7 @@ Suite *baton_suite(void) {
     tcase_add_test(basic, test_init_rods_path);
     tcase_add_test(basic, test_resolve_rods_path);
     tcase_add_test(basic, test_make_query_input);
+    tcase_add_test(basic, test_add_query_conds_rejects_too_many_conditions);
 
      TCase *path = tcase_create("path");
      tcase_add_unchecked_fixture(path, setup, teardown);


### PR DESCRIPTION
Add a bounds check for the maximum permitted number of query parameters.

Add a test for exceeding the maximum.